### PR TITLE
Add embeddable Preact product card

### DIFF
--- a/routes/embed/download.ts
+++ b/routes/embed/download.ts
@@ -1,3 +1,4 @@
+
 import { Handlers } from "$fresh/server.ts";
 
 const embedUrl = "http://localhost:8000/embed/product";

--- a/routes/embed/download.ts
+++ b/routes/embed/download.ts
@@ -1,0 +1,45 @@
+import { Handlers } from "$fresh/server.ts";
+
+const embedUrl = "/embed/product";
+const lazySrc = "/embed/lazy-app";
+
+const fullPageHtml = `<!doctype html>
+<html lang="cs">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Denof UI embed demo</title>
+    <style>
+      body { margin: 0; font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; background: #f8fafc; color: #0f172a; }
+      main { padding: 32px; display: grid; gap: 24px; }
+      .section { background: white; border-radius: 14px; padding: 18px; box-shadow: 0 12px 36px rgba(15, 23, 42, 0.08); border: 1px solid #e2e8f0; }
+      .section h2 { margin-top: 0; margin-bottom: 8px; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Embedované komponenty z Denof UI</h1>
+      <div class="section">
+        <h2>Click counter</h2>
+        <div data-denof-embed="counter" data-label="Klikni na mě" data-start="2"></div>
+      </div>
+      <div class="section">
+        <h2>Lazy loader</h2>
+        <div data-denof-embed="loader" data-button-label="Načíst appku" data-loaded-label="Hotovo" data-load-src="${lazySrc}"></div>
+      </div>
+      <script type="module" src="${embedUrl}"></script>
+    </main>
+  </body>
+</html>`;
+
+export const handler: Handlers = {
+  GET() {
+    return new Response(fullPageHtml, {
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        "cache-control": "public, max-age=300",
+        "content-disposition": "attachment; filename=denof-embed.html",
+      },
+    });
+  },
+};

--- a/routes/embed/download.ts
+++ b/routes/embed/download.ts
@@ -1,4 +1,3 @@
-
 import { Handlers } from "$fresh/server.ts";
 
 const embedUrl = "http://localhost:8000/embed/product";
@@ -23,18 +22,23 @@ const fullPageHtml = `<!doctype html>
       <h1>Embedované komponenty z Denof UI</h1>
       <p>Vše běží na <strong>http://localhost:8000/embed</strong>. Stačí vložit divy s <code>data-denof-embed</code> a skript.</p>
       <div class="section">
+        <h2>Hlavní shell s Preactem</h2>
+        <p>Jedna embedovaná komponenta, která sdílí stav mezi counterem, stavovou kartou a lazy loaderem.</p>
+        <div data-denof-embed="shell" data-heading="Denof UI embed shell" data-description="Sdílený stav a SSR-ready skelet"></div>
+      </div>
+      <div class="section">
         <h2>Click counter</h2>
-        <p>Používá hook useState a ukazuje základní integraci.</p>
+        <p>Používá hook useState a ukazuje základní integraci. Odesílá události, které poslouchá stavová karta.</p>
         <div data-denof-embed="counter" data-label="Klikni na mě" data-start="2"></div>
       </div>
       <div class="section">
         <h2>Stavová karta</h2>
-        <p>SSR-friendly výstup s hooky, který ukazuje stav služby a aktualizuje čas razítka.</p>
+        <p>SSR-friendly výstup s hooky, který ukazuje stav služby a reaguje na události counteru i lazy loaderu.</p>
         <div data-denof-embed="status" data-label="Stav služby" data-status="Online" data-detail="Vše běží hladce"></div>
       </div>
       <div class="section">
         <h2>Lazy loader</h2>
-        <p>Na kliknutí stáhne zbytek aplikace z ${lazySrc} a vykreslí ji.</p>
+        <p>Na kliknutí stáhne zbytek aplikace z ${lazySrc} a vykreslí ji. Po načtení vyšle událost, kterou může zachytit stavová karta.</p>
         <div data-denof-embed="loader" data-button-label="Načíst appku" data-loaded-label="Hotovo" data-load-src="${lazySrc}"></div>
       </div>
       <script type="module" src="${embedUrl}"></script>

--- a/routes/embed/download.ts
+++ b/routes/embed/download.ts
@@ -1,7 +1,7 @@
 import { Handlers } from "$fresh/server.ts";
 
-const embedUrl = "/embed/product";
-const lazySrc = "/embed/lazy-app";
+const embedUrl = "http://localhost:8000/embed/product";
+const lazySrc = "http://localhost:8000/embed/lazy-app";
 
 const fullPageHtml = `<!doctype html>
 <html lang="cs">
@@ -11,20 +11,29 @@ const fullPageHtml = `<!doctype html>
     <title>Denof UI embed demo</title>
     <style>
       body { margin: 0; font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; background: #f8fafc; color: #0f172a; }
-      main { padding: 32px; display: grid; gap: 24px; }
+      main { padding: 32px; display: grid; gap: 24px; max-width: 960px; margin: 0 auto; }
       .section { background: white; border-radius: 14px; padding: 18px; box-shadow: 0 12px 36px rgba(15, 23, 42, 0.08); border: 1px solid #e2e8f0; }
       .section h2 { margin-top: 0; margin-bottom: 8px; }
+      .section p { margin-top: 0; color: #475569; }
     </style>
   </head>
   <body>
     <main>
       <h1>Embedované komponenty z Denof UI</h1>
+      <p>Vše běží na <strong>http://localhost:8000/embed</strong>. Stačí vložit divy s <code>data-denof-embed</code> a skript.</p>
       <div class="section">
         <h2>Click counter</h2>
+        <p>Používá hook useState a ukazuje základní integraci.</p>
         <div data-denof-embed="counter" data-label="Klikni na mě" data-start="2"></div>
       </div>
       <div class="section">
+        <h2>Stavová karta</h2>
+        <p>SSR-friendly výstup s hooky, který ukazuje stav služby a aktualizuje čas razítka.</p>
+        <div data-denof-embed="status" data-label="Stav služby" data-status="Online" data-detail="Vše běží hladce"></div>
+      </div>
+      <div class="section">
         <h2>Lazy loader</h2>
+        <p>Na kliknutí stáhne zbytek aplikace z ${lazySrc} a vykreslí ji.</p>
         <div data-denof-embed="loader" data-button-label="Načíst appku" data-loaded-label="Hotovo" data-load-src="${lazySrc}"></div>
       </div>
       <script type="module" src="${embedUrl}"></script>

--- a/routes/embed/index.tsx
+++ b/routes/embed/index.tsx
@@ -1,0 +1,86 @@
+import productData from "../../data/product.json" assert { type: "json" };
+
+const embedUrl = "/embed/product";
+const defaultPayload = {
+  title: productData.title,
+  price: productData.price,
+  oldPrice: productData.priceRrp,
+  currency: "EUR",
+  description:
+    "Robotski sesalnik z 8200 Pa in pametno navigacijo. Idealno za velike površine in hitro čiščenje.",
+  image: (productData.images as string[])[0],
+  rating: productData.rank?.rating ?? 4.8,
+  count: productData.rank?.count ?? 4,
+  coupon: productData.coupon?.percentualValue ?? 0,
+};
+
+const codeSample = `<div data-denof-embed="product"
+  data-title="${defaultPayload.title}"
+  data-price="${defaultPayload.price}"
+  data-old-price="${defaultPayload.oldPrice}"
+  data-currency="${defaultPayload.currency}"
+  data-description="${defaultPayload.description}"
+  data-image="${defaultPayload.image}"
+  data-rating="${defaultPayload.rating}"
+  data-count="${defaultPayload.count}"
+  data-coupon="${defaultPayload.coupon}"></div>
+<script type="module" src="${embedUrl}"></script>`;
+
+export default function EmbedPage() {
+  return (
+    <div class="container py-5">
+      <div class="row g-4">
+        <div class="col-12 col-lg-6">
+          <h1 class="fw-bold">Vdelana Preact kartica izdelka</h1>
+          <p class="text-secondary">
+            Na tem naslovu najdeš generiran modul, ki renderira Preact komponento neposredno
+            v poljuben HTML. Dodaj <code>div</code> z atributom <code>data-denof-embed="product"</code>, posreduj
+            podatke in naloži skripto iz <code>{embedUrl}</code>. Ni potrebe po dodatnih
+            build korakih – vse dela samo s Preactom.
+          </p>
+
+          <div class="bg-light border rounded-4 p-3">
+            <p class="mb-2 fw-semibold">Hitro kopiranje</p>
+            <pre class="bg-dark text-white rounded-3 p-3 small overflow-auto" style="max-height: 320px;">
+              <code>{codeSample}</code>
+            </pre>
+          </div>
+
+          <h2 class="h5 mt-4">Podprti atributi</h2>
+          <ul class="list-group list-group-flush">
+            <li class="list-group-item">data-title, data-description, data-image</li>
+            <li class="list-group-item">data-price, data-old-price, data-currency</li>
+            <li class="list-group-item">data-rating, data-count, data-coupon</li>
+            <li class="list-group-item">data-payload (JSON string s poljubnimi polji zgoraj)</li>
+          </ul>
+        </div>
+
+        <div class="col-12 col-lg-6">
+          <div class="card shadow-sm border-0">
+            <div class="card-header bg-white">
+              <div class="d-flex align-items-center justify-content-between">
+                <span class="fw-semibold">Živa predogledna kartica</span>
+                <span class="badge text-bg-dark">{embedUrl}</span>
+              </div>
+            </div>
+            <div class="card-body">
+              <div
+                data-denof-embed="product"
+                data-title={defaultPayload.title}
+                data-price={defaultPayload.price}
+                data-old-price={defaultPayload.oldPrice}
+                data-currency={defaultPayload.currency}
+                data-description={defaultPayload.description}
+                data-image={defaultPayload.image}
+                data-rating={defaultPayload.rating}
+                data-count={defaultPayload.count}
+                data-coupon={defaultPayload.coupon}
+              ></div>
+              <script type="module" src={embedUrl}></script>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/routes/embed/index.tsx
+++ b/routes/embed/index.tsx
@@ -1,5 +1,5 @@
-const embedUrl = "/embed/product";
-const lazySrc = "/embed/lazy-app";
+const embedUrl = "http://localhost:8000/embed/product";
+const lazySrc = "http://localhost:8000/embed/lazy-app";
 const downloadUrl = "/embed/download";
 const defaultPayload = {
   label: "Klikni na mě",
@@ -10,15 +10,41 @@ const lazyDefaults = {
   loadedLabel: "Aplikace načtena",
   loadSrc: lazySrc,
 };
+const statusDefaults = {
+  label: "Stav služby",
+  status: "Online",
+  detail: "Vše běží hladce",
+  tone: "success",
+};
 
 const codeSample = `<div data-denof-embed="counter"
   data-label="${defaultPayload.label}"
   data-start="${defaultPayload.start}"></div>
+<div data-denof-embed="status"
+  data-label="${statusDefaults.label}"
+  data-status="${statusDefaults.status}"
+  data-detail="${statusDefaults.detail}"></div>
 <div data-denof-embed="loader"
   data-button-label="${lazyDefaults.buttonLabel}"
   data-loaded-label="${lazyDefaults.loadedLabel}"
   data-load-src="${lazyDefaults.loadSrc}"></div>
 <script type="module" src="${embedUrl}"></script>`;
+
+const ssrHtml = `<!doctype html>
+<html lang="cs">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Denof UI embed</title>
+    <link rel="preload" href="${embedUrl}" as="script" />
+  </head>
+  <body>
+    <div data-denof-embed="counter" data-label="${defaultPayload.label}" data-start="2"></div>
+    <div data-denof-embed="status" data-label="${statusDefaults.label}" data-status="Online" data-detail="Vše běží hladce"></div>
+    <div data-denof-embed="loader" data-button-label="${lazyDefaults.buttonLabel}" data-loaded-label="${lazyDefaults.loadedLabel}" data-load-src="${lazyDefaults.loadSrc}"></div>
+    <script type="module" src="${embedUrl}" defer></script>
+  </body>
+</html>`;
 
 const fullPageSample = `<!doctype html>
 <html lang="cs">
@@ -26,13 +52,22 @@ const fullPageSample = `<!doctype html>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Embed counter</title>
+    <style>
+      body { margin: 0; font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; background: #f8fafc; color: #0f172a; }
+      main { padding: 24px; display: grid; gap: 18px; max-width: 900px; margin: 0 auto; }
+    </style>
   </head>
   <body>
-    <main style="padding: 24px; background: #f8fafc; min-height: 100vh; display: grid; gap: 18px;">
+    <main>
       <h1>Ukázková stránka s Preact komponentami</h1>
+      <p>Komponenty se vykreslí ze skriptu dostupného na <strong>http://localhost:8000/embed/product</strong>. Stačí vložit div a script tag.</p>
       <div data-denof-embed="counter"
         data-label="${defaultPayload.label}"
         data-start="${defaultPayload.start}"></div>
+      <div data-denof-embed="status"
+        data-label="${statusDefaults.label}"
+        data-status="${statusDefaults.status}"
+        data-detail="${statusDefaults.detail}"></div>
       <div data-denof-embed="loader"
         data-button-label="${lazyDefaults.buttonLabel}"
         data-loaded-label="${lazyDefaults.loadedLabel}"
@@ -50,8 +85,8 @@ export default function EmbedPage() {
           <h1 class="fw-bold">Vdelaná knihovna Preact komponent</h1>
           <p class="text-secondary">
             Na této adrese najdeš generovaný modul, který sám inicializuje Preact a
-            vykreslí embeddované komponenty (click counter a lazy loader). Stačí
-            přidat <code>div</code> s atributem <code>data-denof-embed</code>, případně
+            vykreslí embeddované komponenty (click counter, stavová karta a lazy loader).
+            Stačí přidat <code>div</code> s atributem <code>data-denof-embed</code>, případně
             poslat data přes atributy nebo JSON payload. Skript Preact načte a zbytek
             zařídí za tebe.
           </p>
@@ -62,7 +97,7 @@ export default function EmbedPage() {
           </p>
 
           <div class="bg-light border rounded-4 p-3">
-            <p class="mb-2 fw-semibold">Rychlé vložení obou komponent</p>
+            <p class="mb-2 fw-semibold">Rychlé vložení tří komponent</p>
             <pre class="bg-dark text-white rounded-3 p-3 small overflow-auto" style="max-height: 320px;">
               <code>{codeSample}</code>
             </pre>
@@ -70,8 +105,11 @@ export default function EmbedPage() {
 
           <h2 class="h5 mt-4">Podporované atributy</h2>
           <ul class="list-group list-group-flush">
-            <li class="list-group-item">data-label – text nad počítadlem</li>
+            <li class="list-group-item">data-label – text nad počítadlem nebo kartou</li>
             <li class="list-group-item">data-start – počáteční hodnota kliků</li>
+            <li class="list-group-item">data-status – text stavu (Online/Warning...)</li>
+            <li class="list-group-item">data-detail – doplňující popis stavu</li>
+            <li class="list-group-item">data-tone – barevný tón stavové tečky (success|warning|danger)</li>
             <li class="list-group-item">data-button-label – text na lazy tlačítku</li>
             <li class="list-group-item">data-loaded-label – text po úspěšném načtení</li>
             <li class="list-group-item">data-load-src – URL modulu, který se má dotáhnout</li>
@@ -79,11 +117,23 @@ export default function EmbedPage() {
           </ul>
 
           <div class="bg-light border rounded-4 p-3 mt-4">
+            <p class="mb-2 fw-semibold">SSR-friendly HTML skeleton</p>
+            <p class="text-secondary small mb-3">
+              Minimalistická stránka, která přednačte embed skript přes <code>preload</code>,
+              hydratuje komponenty po načtení a nechává obsah kompatibilní se SSR.
+            </p>
+            <pre class="bg-dark text-white rounded-3 p-3 small overflow-auto" style="max-height: 340px;">
+              <code>{ssrHtml}</code>
+            </pre>
+          </div>
+
+          <div class="bg-light border rounded-4 p-3 mt-4">
             <p class="mb-2 fw-semibold">Celý HTML příklad</p>
             <p class="text-secondary small mb-3">
               Příklad samostatné stránky, která si jen vloží <code>div</code> a
-              načte generovaný skript. Ten si sám dotáhne Preact, zpracuje data
-              atributy a vykreslí counter.
+              načte generovaný skript z <code>http://localhost:8000/embed/product</code>.
+              Skript si sám dotáhne Preact, zpracuje data atributy a vykreslí counter,
+              stavovou kartu i lazy loader.
             </p>
             <pre class="bg-dark text-white rounded-3 p-3 small overflow-auto" style="max-height: 340px;">
               <code>{fullPageSample}</code>
@@ -95,7 +145,7 @@ export default function EmbedPage() {
         </div>
 
         <div class="col-12 col-lg-6">
-          <div class="card shadow-sm border-0">
+          <div class="card shadow-sm border-0 mb-3">
             <div class="card-header bg-white">
               <div class="d-flex align-items-center justify-content-between">
                 <span class="fw-semibold">Živý náhled counteru</span>
@@ -108,8 +158,37 @@ export default function EmbedPage() {
                 data-label={defaultPayload.label}
                 data-start={defaultPayload.start}
               ></div>
+              <script type="module" src={embedUrl}></script>
+            </div>
+          </div>
+
+          <div class="card shadow-sm border-0 mb-3">
+            <div class="card-header bg-white">
+              <div class="d-flex align-items-center justify-content-between">
+                <span class="fw-semibold">Živá stavová karta</span>
+                <span class="badge text-bg-dark">SSR + hook</span>
+              </div>
+            </div>
+            <div class="card-body">
               <div
-                class="mt-3"
+                data-denof-embed="status"
+                data-label={statusDefaults.label}
+                data-status={statusDefaults.status}
+                data-detail={statusDefaults.detail}
+              ></div>
+              <script type="module" src={embedUrl}></script>
+            </div>
+          </div>
+
+          <div class="card shadow-sm border-0">
+            <div class="card-header bg-white">
+              <div class="d-flex align-items-center justify-content-between">
+                <span class="fw-semibold">Lazy loader ukázka</span>
+                <span class="badge text-bg-dark">/embed/lazy-app</span>
+              </div>
+            </div>
+            <div class="card-body">
+              <div
                 data-denof-embed="loader"
                 data-button-label={lazyDefaults.buttonLabel}
                 data-loaded-label={lazyDefaults.loadedLabel}

--- a/routes/embed/index.tsx
+++ b/routes/embed/index.tsx
@@ -9,6 +9,24 @@ const codeSample = `<div data-denof-embed="counter"
   data-start="${defaultPayload.start}"></div>
 <script type="module" src="${embedUrl}"></script>`;
 
+const fullPageSample = `<!doctype html>
+<html lang="cs">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Embed counter</title>
+  </head>
+  <body>
+    <main style="padding: 24px; background: #f8fafc; min-height: 100vh;">
+      <h1>Ukázková stránka s Preact counterem</h1>
+      <div data-denof-embed="counter"
+        data-label="${defaultPayload.label}"
+        data-start="${defaultPayload.start}"></div>
+      <script type="module" src="${embedUrl}"></script>
+    </main>
+  </body>
+</html>`;
+
 export default function EmbedPage() {
   return (
     <div class="container py-5">
@@ -36,6 +54,18 @@ export default function EmbedPage() {
             <li class="list-group-item">data-start – počáteční hodnota kliků</li>
             <li class="list-group-item">data-payload – JSON string se stejnými klíči</li>
           </ul>
+
+          <div class="bg-light border rounded-4 p-3 mt-4">
+            <p class="mb-2 fw-semibold">Celý HTML příklad</p>
+            <p class="text-secondary small mb-3">
+              Příklad samostatné stránky, která si jen vloží <code>div</code> a
+              načte generovaný skript. Ten si sám dotáhne Preact, zpracuje data
+              atributy a vykreslí counter.
+            </p>
+            <pre class="bg-dark text-white rounded-3 p-3 small overflow-auto" style="max-height: 340px;">
+              <code>{fullPageSample}</code>
+            </pre>
+          </div>
         </div>
 
         <div class="col-12 col-lg-6">

--- a/routes/embed/index.tsx
+++ b/routes/embed/index.tsx
@@ -1,7 +1,7 @@
-
 const embedUrl = "http://localhost:8000/embed/product";
 const lazySrc = "http://localhost:8000/embed/lazy-app";
 const downloadUrl = "/embed/download";
+
 const defaultPayload = {
   label: "Klikni na mě",
   start: 0,
@@ -18,6 +18,12 @@ const statusDefaults = {
   tone: "success",
 };
 
+const shellSnippet = `<div data-denof-embed="shell"
+  data-heading="Denof UI embed shell"
+  data-description="Jeden kontejner s Preactem, který sdílí stav mezi komponentami">
+</div>
+<script type="module" src="${embedUrl}" defer></script>`;
+
 const codeSample = `<div data-denof-embed="counter"
   data-label="${defaultPayload.label}"
   data-start="${defaultPayload.start}"></div>
@@ -29,7 +35,7 @@ const codeSample = `<div data-denof-embed="counter"
   data-button-label="${lazyDefaults.buttonLabel}"
   data-loaded-label="${lazyDefaults.loadedLabel}"
   data-load-src="${lazyDefaults.loadSrc}"></div>
-<script type="module" src="${embedUrl}"></script>`;
+<script type="module" src="${embedUrl}" defer></script>`;
 
 const ssrHtml = `<!doctype html>
 <html lang="cs">
@@ -38,12 +44,12 @@ const ssrHtml = `<!doctype html>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Denof UI embed</title>
     <link rel="preload" href="${embedUrl}" as="script" />
+    <script type="module" src="${embedUrl}" defer></script>
   </head>
   <body>
-    <div data-denof-embed="counter" data-label="${defaultPayload.label}" data-start="2"></div>
+    <div data-denof-embed="shell" data-start="2" data-label="${defaultPayload.label}"></div>
     <div data-denof-embed="status" data-label="${statusDefaults.label}" data-status="Online" data-detail="Vše běží hladce"></div>
     <div data-denof-embed="loader" data-button-label="${lazyDefaults.buttonLabel}" data-loaded-label="${lazyDefaults.loadedLabel}" data-load-src="${lazyDefaults.loadSrc}"></div>
-    <script type="module" src="${embedUrl}" defer></script>
   </body>
 </html>`;
 
@@ -52,7 +58,7 @@ const fullPageSample = `<!doctype html>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Embed counter</title>
+    <title>Embedované komponenty</title>
     <style>
       body { margin: 0; font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; background: #f8fafc; color: #0f172a; }
       main { padding: 24px; display: grid; gap: 18px; max-width: 900px; margin: 0 auto; }
@@ -61,7 +67,11 @@ const fullPageSample = `<!doctype html>
   <body>
     <main>
       <h1>Ukázková stránka s Preact komponentami</h1>
-      <p>Komponenty se vykreslí ze skriptu dostupného na <strong>http://localhost:8000/embed/product</strong>. Stačí vložit div a script tag.</p>
+      <p>Komponenty se vykreslí ze skriptu dostupného na <strong>http://localhost:8000/embed/product</strong>. Stačí vložit divy a jeden script tag.</p>
+      <div data-denof-embed="shell"
+        data-heading="Denof UI embed shell"
+        data-description="Hlavní kontejner sdílí stav mezi counterem, kartou a lazy loaderem"
+        data-start="${defaultPayload.start}"></div>
       <div data-denof-embed="counter"
         data-label="${defaultPayload.label}"
         data-start="${defaultPayload.start}"></div>
@@ -85,17 +95,20 @@ export default function EmbedPage() {
         <div class="col-12 col-lg-6">
           <h1 class="fw-bold">Vdelaná knihovna Preact komponent</h1>
           <p class="text-secondary">
-            Na této adrese najdeš generovaný modul, který sám inicializuje Preact a
-            vykreslí embeddované komponenty (click counter, stavová karta a lazy loader).
-            Stačí přidat <code>div</code> s atributem <code>data-denof-embed</code>, případně
-            poslat data přes atributy nebo JSON payload. Skript Preact načte a zbytek
-            zařídí za tebe.
+            Na této adrese najdeš generovaný modul, který sám inicializuje Preact a vykreslí embeddované komponenty (click counter, stavová karta a lazy loader).
+            Stačí přidat <code>div</code> s atributem <code>data-denof-embed</code>, případně poslat data přes atributy nebo JSON payload. Skript Preact načte a zbytek zařídí za tebe.
           </p>
           <p class="text-secondary">
-            Lazy loader komponenta po kliknutí dotáhne zadaný modul a zobrazí jeho
-            obsah. Můžeš ho využít pro postupné načítání těžších částí aplikace nebo
-            dalších UI prvků až ve chvíli, kdy o ně uživatel projeví zájem.
+            Lazy loader komponenta po kliknutí dotáhne zadaný modul a zobrazí jeho obsah. Můžeš ho využít pro postupné načítání těžších částí aplikace nebo dalších UI prvků až ve chvíli, kdy o ně uživatel projeví zájem.
+            Status karta a counter jsou navzájem propojené přes události, takže můžeš sledovat kliky i stav lazy načítání v samostatných kontejnerech.
           </p>
+
+          <div class="bg-light border rounded-4 p-3 mb-3">
+            <p class="mb-2 fw-semibold">Hlavní embed shell</p>
+            <pre class="bg-dark text-white rounded-3 p-3 small overflow-auto" style="max-height: 240px;">
+              <code>{shellSnippet}</code>
+            </pre>
+          </div>
 
           <div class="bg-light border rounded-4 p-3">
             <p class="mb-2 fw-semibold">Rychlé vložení tří komponent</p>
@@ -111,6 +124,8 @@ export default function EmbedPage() {
             <li class="list-group-item">data-status – text stavu (Online/Warning...)</li>
             <li class="list-group-item">data-detail – doplňující popis stavu</li>
             <li class="list-group-item">data-tone – barevný tón stavové tečky (success|warning|danger)</li>
+            <li class="list-group-item">data-broadcast – vypnutí sdílení událostí counteru</li>
+            <li class="list-group-item">data-listen-to-events – vypnutí odběru událostí u stavové karty</li>
             <li class="list-group-item">data-button-label – text na lazy tlačítku</li>
             <li class="list-group-item">data-loaded-label – text po úspěšném načtení</li>
             <li class="list-group-item">data-load-src – URL modulu, který se má dotáhnout</li>
@@ -120,8 +135,7 @@ export default function EmbedPage() {
           <div class="bg-light border rounded-4 p-3 mt-4">
             <p class="mb-2 fw-semibold">SSR-friendly HTML skeleton</p>
             <p class="text-secondary small mb-3">
-              Minimalistická stránka, která přednačte embed skript přes <code>preload</code>,
-              hydratuje komponenty po načtení a nechává obsah kompatibilní se SSR.
+              Minimalistická stránka, která přednačte embed skript přes <code>preload</code>, hydratuje komponenty po načtení a nechává obsah kompatibilní se SSR.
             </p>
             <pre class="bg-dark text-white rounded-3 p-3 small overflow-auto" style="max-height: 340px;">
               <code>{ssrHtml}</code>
@@ -131,10 +145,8 @@ export default function EmbedPage() {
           <div class="bg-light border rounded-4 p-3 mt-4">
             <p class="mb-2 fw-semibold">Celý HTML příklad</p>
             <p class="text-secondary small mb-3">
-              Příklad samostatné stránky, která si jen vloží <code>div</code> a
-              načte generovaný skript z <code>http://localhost:8000/embed/product</code>.
-              Skript si sám dotáhne Preact, zpracuje data atributy a vykreslí counter,
-              stavovou kartu i lazy loader.
+              Příklad samostatné stránky, která si jen vloží <code>div</code> a načte generovaný skript z <code>http://localhost:8000/embed/product</code>.
+              Skript si sám dotáhne Preact, zpracuje data atributy a vykreslí counter, stavovou kartu i lazy loader. Shell ukazuje sdílený stav mezi komponentami.
             </p>
             <pre class="bg-dark text-white rounded-3 p-3 small overflow-auto" style="max-height: 340px;">
               <code>{fullPageSample}</code>
@@ -149,8 +161,26 @@ export default function EmbedPage() {
           <div class="card shadow-sm border-0 mb-3">
             <div class="card-header bg-white">
               <div class="d-flex align-items-center justify-content-between">
-                <span class="fw-semibold">Živý náhled counteru</span>
+                <span class="fw-semibold">Živý náhled embed shellu</span>
                 <span class="badge text-bg-dark">{embedUrl}</span>
+              </div>
+            </div>
+            <div class="card-body">
+              <div
+                data-denof-embed="shell"
+                data-heading="Denof UI embed shell"
+                data-description="Sdílí stav kliků a lazy načítání mezi komponentami"
+                data-start="0"
+              ></div>
+              <script type="module" src={embedUrl} defer></script>
+            </div>
+          </div>
+
+          <div class="card shadow-sm border-0 mb-3">
+            <div class="card-header bg-white">
+              <div class="d-flex align-items-center justify-content-between">
+                <span class="fw-semibold">Živý counter + status</span>
+                <span class="badge text-bg-dark">SSR + hook</span>
               </div>
             </div>
             <div class="card-body">
@@ -159,25 +189,13 @@ export default function EmbedPage() {
                 data-label={defaultPayload.label}
                 data-start={defaultPayload.start}
               ></div>
-              <script type="module" src={embedUrl}></script>
-            </div>
-          </div>
-
-          <div class="card shadow-sm border-0 mb-3">
-            <div class="card-header bg-white">
-              <div class="d-flex align-items-center justify-content-between">
-                <span class="fw-semibold">Živá stavová karta</span>
-                <span class="badge text-bg-dark">SSR + hook</span>
-              </div>
-            </div>
-            <div class="card-body">
               <div
                 data-denof-embed="status"
                 data-label={statusDefaults.label}
                 data-status={statusDefaults.status}
                 data-detail={statusDefaults.detail}
               ></div>
-              <script type="module" src={embedUrl}></script>
+              <script type="module" src={embedUrl} defer></script>
             </div>
           </div>
 
@@ -195,7 +213,7 @@ export default function EmbedPage() {
                 data-loaded-label={lazyDefaults.loadedLabel}
                 data-load-src={lazyDefaults.loadSrc}
               ></div>
-              <script type="module" src={embedUrl}></script>
+              <script type="module" src={embedUrl} defer></script>
             </div>
           </div>
         </div>

--- a/routes/embed/index.tsx
+++ b/routes/embed/index.tsx
@@ -1,12 +1,23 @@
 const embedUrl = "/embed/product";
+const lazySrc = "/embed/lazy-app";
+const downloadUrl = "/embed/download";
 const defaultPayload = {
   label: "Klikni na mě",
   start: 0,
+};
+const lazyDefaults = {
+  buttonLabel: "Načíst mini appku",
+  loadedLabel: "Aplikace načtena",
+  loadSrc: lazySrc,
 };
 
 const codeSample = `<div data-denof-embed="counter"
   data-label="${defaultPayload.label}"
   data-start="${defaultPayload.start}"></div>
+<div data-denof-embed="loader"
+  data-button-label="${lazyDefaults.buttonLabel}"
+  data-loaded-label="${lazyDefaults.loadedLabel}"
+  data-load-src="${lazyDefaults.loadSrc}"></div>
 <script type="module" src="${embedUrl}"></script>`;
 
 const fullPageSample = `<!doctype html>
@@ -17,11 +28,15 @@ const fullPageSample = `<!doctype html>
     <title>Embed counter</title>
   </head>
   <body>
-    <main style="padding: 24px; background: #f8fafc; min-height: 100vh;">
-      <h1>Ukázková stránka s Preact counterem</h1>
+    <main style="padding: 24px; background: #f8fafc; min-height: 100vh; display: grid; gap: 18px;">
+      <h1>Ukázková stránka s Preact komponentami</h1>
       <div data-denof-embed="counter"
         data-label="${defaultPayload.label}"
         data-start="${defaultPayload.start}"></div>
+      <div data-denof-embed="loader"
+        data-button-label="${lazyDefaults.buttonLabel}"
+        data-loaded-label="${lazyDefaults.loadedLabel}"
+        data-load-src="${lazyDefaults.loadSrc}"></div>
       <script type="module" src="${embedUrl}"></script>
     </main>
   </body>
@@ -32,17 +47,22 @@ export default function EmbedPage() {
     <div class="container py-5">
       <div class="row g-4">
         <div class="col-12 col-lg-6">
-          <h1 class="fw-bold">Vdelaná Preact counter komponenta</h1>
+          <h1 class="fw-bold">Vdelaná knihovna Preact komponent</h1>
           <p class="text-secondary">
             Na této adrese najdeš generovaný modul, který sám inicializuje Preact a
-            vykreslí jednoduchý click-counter. Stačí přidat <code>div</code> s atributem
-            <code>data-denof-embed="counter"</code>, případně poslat počáteční hodnotu a
-            popisek přes data atributy nebo JSON payload. Skript Preact načte a zbytek
+            vykreslí embeddované komponenty (click counter a lazy loader). Stačí
+            přidat <code>div</code> s atributem <code>data-denof-embed</code>, případně
+            poslat data přes atributy nebo JSON payload. Skript Preact načte a zbytek
             zařídí za tebe.
+          </p>
+          <p class="text-secondary">
+            Lazy loader komponenta po kliknutí dotáhne zadaný modul a zobrazí jeho
+            obsah. Můžeš ho využít pro postupné načítání těžších částí aplikace nebo
+            dalších UI prvků až ve chvíli, kdy o ně uživatel projeví zájem.
           </p>
 
           <div class="bg-light border rounded-4 p-3">
-            <p class="mb-2 fw-semibold">Rychlé vložení</p>
+            <p class="mb-2 fw-semibold">Rychlé vložení obou komponent</p>
             <pre class="bg-dark text-white rounded-3 p-3 small overflow-auto" style="max-height: 320px;">
               <code>{codeSample}</code>
             </pre>
@@ -52,6 +72,9 @@ export default function EmbedPage() {
           <ul class="list-group list-group-flush">
             <li class="list-group-item">data-label – text nad počítadlem</li>
             <li class="list-group-item">data-start – počáteční hodnota kliků</li>
+            <li class="list-group-item">data-button-label – text na lazy tlačítku</li>
+            <li class="list-group-item">data-loaded-label – text po úspěšném načtení</li>
+            <li class="list-group-item">data-load-src – URL modulu, který se má dotáhnout</li>
             <li class="list-group-item">data-payload – JSON string se stejnými klíči</li>
           </ul>
 
@@ -65,6 +88,9 @@ export default function EmbedPage() {
             <pre class="bg-dark text-white rounded-3 p-3 small overflow-auto" style="max-height: 340px;">
               <code>{fullPageSample}</code>
             </pre>
+            <a class="btn btn-dark mt-3" href={downloadUrl} download>
+              Stáhnout hotovou HTML stránku
+            </a>
           </div>
         </div>
 
@@ -81,6 +107,13 @@ export default function EmbedPage() {
                 data-denof-embed="counter"
                 data-label={defaultPayload.label}
                 data-start={defaultPayload.start}
+              ></div>
+              <div
+                class="mt-3"
+                data-denof-embed="loader"
+                data-button-label={lazyDefaults.buttonLabel}
+                data-loaded-label={lazyDefaults.loadedLabel}
+                data-load-src={lazyDefaults.loadSrc}
               ></div>
               <script type="module" src={embedUrl}></script>
             </div>

--- a/routes/embed/index.tsx
+++ b/routes/embed/index.tsx
@@ -1,3 +1,4 @@
+
 const embedUrl = "http://localhost:8000/embed/product";
 const lazySrc = "http://localhost:8000/embed/lazy-app";
 const downloadUrl = "/embed/download";

--- a/routes/embed/index.tsx
+++ b/routes/embed/index.tsx
@@ -1,29 +1,12 @@
-import productData from "../../data/product.json" assert { type: "json" };
-
 const embedUrl = "/embed/product";
 const defaultPayload = {
-  title: productData.title,
-  price: productData.price,
-  oldPrice: productData.priceRrp,
-  currency: "EUR",
-  description:
-    "Robotski sesalnik z 8200 Pa in pametno navigacijo. Idealno za velike površine in hitro čiščenje.",
-  image: (productData.images as string[])[0],
-  rating: productData.rank?.rating ?? 4.8,
-  count: productData.rank?.count ?? 4,
-  coupon: productData.coupon?.percentualValue ?? 0,
+  label: "Klikni na mě",
+  start: 0,
 };
 
-const codeSample = `<div data-denof-embed="product"
-  data-title="${defaultPayload.title}"
-  data-price="${defaultPayload.price}"
-  data-old-price="${defaultPayload.oldPrice}"
-  data-currency="${defaultPayload.currency}"
-  data-description="${defaultPayload.description}"
-  data-image="${defaultPayload.image}"
-  data-rating="${defaultPayload.rating}"
-  data-count="${defaultPayload.count}"
-  data-coupon="${defaultPayload.coupon}"></div>
+const codeSample = `<div data-denof-embed="counter"
+  data-label="${defaultPayload.label}"
+  data-start="${defaultPayload.start}"></div>
 <script type="module" src="${embedUrl}"></script>`;
 
 export default function EmbedPage() {
@@ -31,27 +14,27 @@ export default function EmbedPage() {
     <div class="container py-5">
       <div class="row g-4">
         <div class="col-12 col-lg-6">
-          <h1 class="fw-bold">Vdelana Preact kartica izdelka</h1>
+          <h1 class="fw-bold">Vdelaná Preact counter komponenta</h1>
           <p class="text-secondary">
-            Na tem naslovu najdeš generiran modul, ki renderira Preact komponento neposredno
-            v poljuben HTML. Dodaj <code>div</code> z atributom <code>data-denof-embed="product"</code>, posreduj
-            podatke in naloži skripto iz <code>{embedUrl}</code>. Ni potrebe po dodatnih
-            build korakih – vse dela samo s Preactom.
+            Na této adrese najdeš generovaný modul, který sám inicializuje Preact a
+            vykreslí jednoduchý click-counter. Stačí přidat <code>div</code> s atributem
+            <code>data-denof-embed="counter"</code>, případně poslat počáteční hodnotu a
+            popisek přes data atributy nebo JSON payload. Skript Preact načte a zbytek
+            zařídí za tebe.
           </p>
 
           <div class="bg-light border rounded-4 p-3">
-            <p class="mb-2 fw-semibold">Hitro kopiranje</p>
+            <p class="mb-2 fw-semibold">Rychlé vložení</p>
             <pre class="bg-dark text-white rounded-3 p-3 small overflow-auto" style="max-height: 320px;">
               <code>{codeSample}</code>
             </pre>
           </div>
 
-          <h2 class="h5 mt-4">Podprti atributi</h2>
+          <h2 class="h5 mt-4">Podporované atributy</h2>
           <ul class="list-group list-group-flush">
-            <li class="list-group-item">data-title, data-description, data-image</li>
-            <li class="list-group-item">data-price, data-old-price, data-currency</li>
-            <li class="list-group-item">data-rating, data-count, data-coupon</li>
-            <li class="list-group-item">data-payload (JSON string s poljubnimi polji zgoraj)</li>
+            <li class="list-group-item">data-label – text nad počítadlem</li>
+            <li class="list-group-item">data-start – počáteční hodnota kliků</li>
+            <li class="list-group-item">data-payload – JSON string se stejnými klíči</li>
           </ul>
         </div>
 
@@ -59,22 +42,15 @@ export default function EmbedPage() {
           <div class="card shadow-sm border-0">
             <div class="card-header bg-white">
               <div class="d-flex align-items-center justify-content-between">
-                <span class="fw-semibold">Živa predogledna kartica</span>
+                <span class="fw-semibold">Živý náhled counteru</span>
                 <span class="badge text-bg-dark">{embedUrl}</span>
               </div>
             </div>
             <div class="card-body">
               <div
-                data-denof-embed="product"
-                data-title={defaultPayload.title}
-                data-price={defaultPayload.price}
-                data-old-price={defaultPayload.oldPrice}
-                data-currency={defaultPayload.currency}
-                data-description={defaultPayload.description}
-                data-image={defaultPayload.image}
-                data-rating={defaultPayload.rating}
-                data-count={defaultPayload.count}
-                data-coupon={defaultPayload.coupon}
+                data-denof-embed="counter"
+                data-label={defaultPayload.label}
+                data-start={defaultPayload.start}
               ></div>
               <script type="module" src={embedUrl}></script>
             </div>

--- a/routes/embed/lazy-app.ts
+++ b/routes/embed/lazy-app.ts
@@ -1,0 +1,54 @@
+import { Handlers } from "$fresh/server.ts";
+
+const script = `import { h, render } from "https://esm.sh/preact@10.22.0";
+
+const LazyApp = () => {
+  return h("div", { class: "denof-lazy-app" }, [
+    h("p", { class: "denof-lazy-app__title" }, "Mini aplikace byla načtena"),
+    h(
+      "p",
+      { class: "denof-lazy-app__text" },
+      "Tento blok se stáhne až po kliknutí na tlačítko a může v sobě načítat další UI knihovnu."
+    ),
+    h(
+      "a",
+      {
+        class: "denof-lazy-app__cta",
+        href: "https://deno.land",
+        target: "_blank",
+        rel: "noreferrer",
+      },
+      "Přejít na dokumentaci"
+    ),
+  ]);
+};
+
+export async function mountLazyApp(target) {
+  const existingStyle = document.querySelector('style[data-denof="lazy-app"]');
+  if (!existingStyle) {
+    const style = document.createElement("style");
+    style.dataset.denof = "lazy-app";
+    style.textContent = `
+      .denof-lazy-app { padding: 14px 16px; border-radius: 12px; background: white; box-shadow: 0 12px 34px rgba(0, 0, 0, 0.08); border: 1px solid #e5e7eb; }
+      .denof-lazy-app__title { margin: 0 0 8px; font-weight: 800; color: #0f172a; font-size: 18px; }
+      .denof-lazy-app__text { margin: 0 0 12px; color: #475569; }
+      .denof-lazy-app__cta { display: inline-flex; align-items: center; gap: 8px; background: linear-gradient(90deg, #22c55e, #16a34a); color: white; padding: 10px 14px; border-radius: 10px; text-decoration: none; font-weight: 700; }
+    `;
+    document.head.appendChild(style);
+  }
+
+  render(h(LazyApp, {}), target);
+}
+
+export default mountLazyApp;
+
+export const handler: Handlers = {
+  GET() {
+    return new Response(script, {
+      headers: {
+        "content-type": "application/javascript; charset=utf-8",
+        "cache-control": "public, max-age=3600",
+      },
+    });
+  },
+};

--- a/routes/embed/lazy-app.ts
+++ b/routes/embed/lazy-app.ts
@@ -1,6 +1,13 @@
 import { Handlers } from "$fresh/server.ts";
 
-const script = `import { h, render } from "https://esm.sh/preact@10.22.0";
+const styles = String.raw`
+  .denof-lazy-app { padding: 14px 16px; border-radius: 12px; background: white; box-shadow: 0 12px 34px rgba(0, 0, 0, 0.08); border: 1px solid #e5e7eb; }
+  .denof-lazy-app__title { margin: 0 0 8px; font-weight: 800; color: #0f172a; font-size: 18px; }
+  .denof-lazy-app__text { margin: 0 0 12px; color: #475569; }
+  .denof-lazy-app__cta { display: inline-flex; align-items: center; gap: 8px; background: linear-gradient(90deg, #22c55e, #16a34a); color: white; padding: 10px 14px; border-radius: 10px; text-decoration: none; font-weight: 700; }
+`;
+
+const script = String.raw`import { h, render } from "https://esm.sh/preact@10.22.0";
 
 const LazyApp = () => {
   return h("div", { class: "denof-lazy-app" }, [
@@ -28,12 +35,7 @@ export async function mountLazyApp(target) {
   if (!existingStyle) {
     const style = document.createElement("style");
     style.dataset.denof = "lazy-app";
-    style.textContent = `
-      .denof-lazy-app { padding: 14px 16px; border-radius: 12px; background: white; box-shadow: 0 12px 34px rgba(0, 0, 0, 0.08); border: 1px solid #e5e7eb; }
-      .denof-lazy-app__title { margin: 0 0 8px; font-weight: 800; color: #0f172a; font-size: 18px; }
-      .denof-lazy-app__text { margin: 0 0 12px; color: #475569; }
-      .denof-lazy-app__cta { display: inline-flex; align-items: center; gap: 8px; background: linear-gradient(90deg, #22c55e, #16a34a); color: white; padding: 10px 14px; border-radius: 10px; text-decoration: none; font-weight: 700; }
-    `;
+    style.textContent = ${JSON.stringify(styles)};
     document.head.appendChild(style);
   }
 

--- a/routes/embed/product.ts
+++ b/routes/embed/product.ts
@@ -53,7 +53,11 @@ const Counter = ({ label, start }) => {
 
   return h("div", { class: "denof-counter" }, [
     h("p", { class: "denof-counter__label" }, label),
-    h("p", { class: "denof-counter__value", role: "status", "aria-live": "polite" }, \`Počítadlo: \\${count}\`),
+    h(
+      "p",
+      { class: "denof-counter__value", role: "status", "aria-live": "polite" },
+      \`Počítadlo: ${"${count}"}\`
+    ),
     h(
       "button",
       { class: "denof-counter__button", type: "button", onClick: () => setCount((value) => value + 1) },

--- a/routes/embed/product.ts
+++ b/routes/embed/product.ts
@@ -1,50 +1,29 @@
 import { Handlers } from "$fresh/server.ts";
-import productData from "../../data/product.json" assert { type: "json" };
 
-const defaultCard = {
-  title: productData.title as string,
-  price: productData.price as number,
-  oldPrice: productData.priceRrp as number,
-  currency: "EUR",
-  description:
-    "Robotski sesalnik z 8200 Pa, samodejnim pomivanjem in pametnimi senzorji za velike površine.",
-  image: (productData.images as string[])[0],
-  rating: productData.rank?.rating ?? 4.8,
-  count: productData.rank?.count ?? 4,
-  coupon: productData.coupon?.percentualValue,
+const defaultConfig = {
+  label: "Klikni na mě",
+  start: 0,
 };
 
 export const handler: Handlers = {
   GET() {
     const script = `import { h, render } from "https://esm.sh/preact@10.22.0";
-import { useMemo } from "https://esm.sh/preact@10.22.0/hooks";
+import { useState } from "https://esm.sh/preact@10.22.0/hooks";
 
-const defaultCard = ${JSON.stringify(defaultCard)};
+const defaultConfig = ${JSON.stringify(defaultConfig)};
 
 const style = document.createElement("style");
-style.dataset.denof = "product-embed";
+style.dataset.denof = "counter-embed";
 style.textContent = `
-  .denof-card { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; border: 1px solid #e5e7eb; border-radius: 16px; overflow: hidden; box-shadow: 0 14px 38px rgba(15, 23, 42, 0.08); max-width: 360px; }
-  .denof-card__media { position: relative; }
-  .denof-card__media img { width: 100%; height: 220px; object-fit: cover; display: block; }
-  .denof-card__badge { position: absolute; top: 12px; left: 12px; background: #111827; color: white; padding: 6px 12px; border-radius: 999px; font-weight: 700; font-size: 12px; letter-spacing: 0.04em; }
-  .denof-card__body { padding: 16px 18px 20px; display: grid; gap: 10px; }
-  .denof-card__title { font-size: 18px; color: #0f172a; font-weight: 700; margin: 0; line-height: 1.35; }
-  .denof-card__desc { color: #4b5563; font-size: 14px; margin: 0; line-height: 1.6; }
-  .denof-card__price { display: flex; align-items: baseline; gap: 8px; }
-  .denof-card__price strong { font-size: 22px; color: #0f172a; }
-  .denof-card__price small { color: #6b7280; text-decoration: line-through; }
-  .denof-card__cta { background: linear-gradient(90deg, #111827, #1f2937); color: white; border: none; padding: 12px 14px; border-radius: 12px; font-weight: 700; cursor: pointer; transition: transform 150ms ease, box-shadow 150ms ease; }
-  .denof-card__cta:hover { transform: translateY(-1px); box-shadow: 0 16px 40px rgba(17, 24, 39, 0.12); }
-  .denof-card__rating { color: #f59e0b; font-weight: 700; font-size: 14px; }
-  .denof-card__meta { display: flex; justify-content: space-between; align-items: center; }
+  .denof-counter { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; border: 1px solid #e5e7eb; border-radius: 12px; padding: 14px 16px; max-width: 280px; background: white; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.07); }
+  .denof-counter__label { margin: 0 0 10px; color: #0f172a; font-weight: 700; font-size: 16px; }
+  .denof-counter__value { display: inline-flex; align-items: center; gap: 8px; margin: 0 0 12px; color: #111827; font-weight: 700; font-size: 18px; }
+  .denof-counter__button { background: linear-gradient(90deg, #0ea5e9, #6366f1); color: white; border: none; padding: 10px 14px; border-radius: 10px; font-weight: 700; cursor: pointer; transition: transform 150ms ease, box-shadow 150ms ease; }
+  .denof-counter__button:hover { transform: translateY(-1px); box-shadow: 0 14px 32px rgba(59, 130, 246, 0.35); }
 `;
-if (!document.querySelector('style[data-denof="product-embed"]')) {
+if (!document.querySelector('style[data-denof="counter-embed"]')) {
   document.head.appendChild(style);
 }
-
-const formatPrice = (value, currency) =>
-  new Intl.NumberFormat("sl-SI", { style: "currency", currency }).format(value);
 
 const parseNumber = (value, fallback) => {
   const parsed = Number(value);
@@ -52,67 +31,42 @@ const parseNumber = (value, fallback) => {
 };
 
 const applyData = (target) => {
-  const enriched = { ...defaultCard };
+  const enriched = { ...defaultConfig };
 
   if (target.dataset.payload) {
     try {
-      const parsed = JSON.parse(target.dataset.payload);
-      Object.assign(enriched, parsed);
+      Object.assign(enriched, JSON.parse(target.dataset.payload));
     } catch (err) {
-      console.warn("Neveljaven JSON v data-payload", err);
+      console.warn("Neplatný JSON v data-payload", err);
     }
   }
 
-  if (target.dataset.title) enriched.title = target.dataset.title;
-  if (target.dataset.image) enriched.image = target.dataset.image;
-  if (target.dataset.description) enriched.description = target.dataset.description;
-  if (target.dataset.currency) enriched.currency = target.dataset.currency;
-  if (target.dataset.rating)
-    enriched.rating = parseNumber(target.dataset.rating, enriched.rating);
-  if (target.dataset.count)
-    enriched.count = parseNumber(target.dataset.count, enriched.count);
-  if (target.dataset.coupon)
-    enriched.coupon = parseNumber(target.dataset.coupon, enriched.coupon);
-  if (target.dataset.price)
-    enriched.price = parseNumber(target.dataset.price, enriched.price);
-  if (target.dataset.oldPrice)
-    enriched.oldPrice = parseNumber(target.dataset.oldPrice, enriched.oldPrice ?? enriched.price * 1.35);
+  if (target.dataset.label) enriched.label = target.dataset.label;
+  if (target.dataset.start)
+    enriched.start = parseNumber(target.dataset.start, enriched.start);
 
   return enriched;
 };
 
-const ProductCard = (props) => {
-  const { title, description, price, oldPrice, currency, image, rating, count, coupon } = props;
-  const badgeLabel = useMemo(() =>
-    coupon ? `-${coupon}%` : "TOP IZBIRA",
-  [coupon]);
+const Counter = ({ label, start }) => {
+  const [count, setCount] = useState(start);
 
-  return h("article", { class: "denof-card" }, [
-    h("div", { class: "denof-card__media" }, [
-      h("img", { src: image, alt: title }),
-      h("span", { class: "denof-card__badge" }, badgeLabel),
-    ]),
-    h("div", { class: "denof-card__body" }, [
-      h("p", { class: "denof-card__rating", role: "img", "aria-label": `${rating} zvezdic od ${count} ocen` }, `★ ${rating} (${count})`),
-      h("h3", { class: "denof-card__title" }, title),
-      h("p", { class: "denof-card__desc" }, description),
-      h("div", { class: "denof-card__price" }, [
-        h("strong", null, formatPrice(price, currency)),
-        oldPrice ? h("small", null, formatPrice(oldPrice, currency)) : null,
-      ]),
-      h("div", { class: "denof-card__meta" }, [
-        h("span", { style: "color:#10b981;font-weight:700;font-size:14px;" }, "Na zalogi"),
-        h("button", { class: "denof-card__cta", type: "button" }, "Dodaj v košarico"),
-      ]),
-    ]),
+  return h("div", { class: "denof-counter" }, [
+    h("p", { class: "denof-counter__label" }, label),
+    h("p", { class: "denof-counter__value", role: "status", "aria-live": "polite" }, `Počítadlo: ${count}`),
+    h(
+      "button",
+      { class: "denof-counter__button", type: "button", onClick: () => setCount((value) => value + 1) },
+      "Přidat klik"
+    ),
   ]);
 };
 
 const mountAll = () => {
-  const targets = document.querySelectorAll('[data-denof-embed="product"]');
+  const targets = document.querySelectorAll('[data-denof-embed="counter"]');
   targets.forEach((target) => {
     const data = applyData(target);
-    render(h(ProductCard, data), target);
+    render(h(Counter, data), target);
   });
 };
 

--- a/routes/embed/product.ts
+++ b/routes/embed/product.ts
@@ -1,0 +1,133 @@
+import { Handlers } from "$fresh/server.ts";
+import productData from "../../data/product.json" assert { type: "json" };
+
+const defaultCard = {
+  title: productData.title as string,
+  price: productData.price as number,
+  oldPrice: productData.priceRrp as number,
+  currency: "EUR",
+  description:
+    "Robotski sesalnik z 8200 Pa, samodejnim pomivanjem in pametnimi senzorji za velike površine.",
+  image: (productData.images as string[])[0],
+  rating: productData.rank?.rating ?? 4.8,
+  count: productData.rank?.count ?? 4,
+  coupon: productData.coupon?.percentualValue,
+};
+
+export const handler: Handlers = {
+  GET() {
+    const script = `import { h, render } from "https://esm.sh/preact@10.22.0";
+import { useMemo } from "https://esm.sh/preact@10.22.0/hooks";
+
+const defaultCard = ${JSON.stringify(defaultCard)};
+
+const style = document.createElement("style");
+style.dataset.denof = "product-embed";
+style.textContent = `
+  .denof-card { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; border: 1px solid #e5e7eb; border-radius: 16px; overflow: hidden; box-shadow: 0 14px 38px rgba(15, 23, 42, 0.08); max-width: 360px; }
+  .denof-card__media { position: relative; }
+  .denof-card__media img { width: 100%; height: 220px; object-fit: cover; display: block; }
+  .denof-card__badge { position: absolute; top: 12px; left: 12px; background: #111827; color: white; padding: 6px 12px; border-radius: 999px; font-weight: 700; font-size: 12px; letter-spacing: 0.04em; }
+  .denof-card__body { padding: 16px 18px 20px; display: grid; gap: 10px; }
+  .denof-card__title { font-size: 18px; color: #0f172a; font-weight: 700; margin: 0; line-height: 1.35; }
+  .denof-card__desc { color: #4b5563; font-size: 14px; margin: 0; line-height: 1.6; }
+  .denof-card__price { display: flex; align-items: baseline; gap: 8px; }
+  .denof-card__price strong { font-size: 22px; color: #0f172a; }
+  .denof-card__price small { color: #6b7280; text-decoration: line-through; }
+  .denof-card__cta { background: linear-gradient(90deg, #111827, #1f2937); color: white; border: none; padding: 12px 14px; border-radius: 12px; font-weight: 700; cursor: pointer; transition: transform 150ms ease, box-shadow 150ms ease; }
+  .denof-card__cta:hover { transform: translateY(-1px); box-shadow: 0 16px 40px rgba(17, 24, 39, 0.12); }
+  .denof-card__rating { color: #f59e0b; font-weight: 700; font-size: 14px; }
+  .denof-card__meta { display: flex; justify-content: space-between; align-items: center; }
+`;
+if (!document.querySelector('style[data-denof="product-embed"]')) {
+  document.head.appendChild(style);
+}
+
+const formatPrice = (value, currency) =>
+  new Intl.NumberFormat("sl-SI", { style: "currency", currency }).format(value);
+
+const parseNumber = (value, fallback) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const applyData = (target) => {
+  const enriched = { ...defaultCard };
+
+  if (target.dataset.payload) {
+    try {
+      const parsed = JSON.parse(target.dataset.payload);
+      Object.assign(enriched, parsed);
+    } catch (err) {
+      console.warn("Neveljaven JSON v data-payload", err);
+    }
+  }
+
+  if (target.dataset.title) enriched.title = target.dataset.title;
+  if (target.dataset.image) enriched.image = target.dataset.image;
+  if (target.dataset.description) enriched.description = target.dataset.description;
+  if (target.dataset.currency) enriched.currency = target.dataset.currency;
+  if (target.dataset.rating)
+    enriched.rating = parseNumber(target.dataset.rating, enriched.rating);
+  if (target.dataset.count)
+    enriched.count = parseNumber(target.dataset.count, enriched.count);
+  if (target.dataset.coupon)
+    enriched.coupon = parseNumber(target.dataset.coupon, enriched.coupon);
+  if (target.dataset.price)
+    enriched.price = parseNumber(target.dataset.price, enriched.price);
+  if (target.dataset.oldPrice)
+    enriched.oldPrice = parseNumber(target.dataset.oldPrice, enriched.oldPrice ?? enriched.price * 1.35);
+
+  return enriched;
+};
+
+const ProductCard = (props) => {
+  const { title, description, price, oldPrice, currency, image, rating, count, coupon } = props;
+  const badgeLabel = useMemo(() =>
+    coupon ? `-${coupon}%` : "TOP IZBIRA",
+  [coupon]);
+
+  return h("article", { class: "denof-card" }, [
+    h("div", { class: "denof-card__media" }, [
+      h("img", { src: image, alt: title }),
+      h("span", { class: "denof-card__badge" }, badgeLabel),
+    ]),
+    h("div", { class: "denof-card__body" }, [
+      h("p", { class: "denof-card__rating", role: "img", "aria-label": `${rating} zvezdic od ${count} ocen` }, `★ ${rating} (${count})`),
+      h("h3", { class: "denof-card__title" }, title),
+      h("p", { class: "denof-card__desc" }, description),
+      h("div", { class: "denof-card__price" }, [
+        h("strong", null, formatPrice(price, currency)),
+        oldPrice ? h("small", null, formatPrice(oldPrice, currency)) : null,
+      ]),
+      h("div", { class: "denof-card__meta" }, [
+        h("span", { style: "color:#10b981;font-weight:700;font-size:14px;" }, "Na zalogi"),
+        h("button", { class: "denof-card__cta", type: "button" }, "Dodaj v košarico"),
+      ]),
+    ]),
+  ]);
+};
+
+const mountAll = () => {
+  const targets = document.querySelectorAll('[data-denof-embed="product"]');
+  targets.forEach((target) => {
+    const data = applyData(target);
+    render(h(ProductCard, data), target);
+  });
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", mountAll);
+} else {
+  mountAll();
+}
+`;
+
+    return new Response(script, {
+      headers: {
+        "content-type": "application/javascript; charset=utf-8",
+        "cache-control": "public, max-age=3600",
+      },
+    });
+  },
+};

--- a/routes/embed/product.ts
+++ b/routes/embed/product.ts
@@ -11,13 +11,21 @@ const defaultLoaderConfig = {
   loadSrc: "/embed/lazy-app",
 };
 
+const defaultStatusConfig = {
+  label: "Stav služby",
+  status: "Online",
+  detail: "Vše běží hladce",
+  tone: "success",
+};
+
 export const handler: Handlers = {
   GET() {
     const script = `import { h, render } from "https://esm.sh/preact@10.22.0";
-import { useRef, useState } from "https://esm.sh/preact@10.22.0/hooks";
+import { useEffect, useRef, useState } from "https://esm.sh/preact@10.22.0/hooks";
 
 const defaultCounterConfig = ${JSON.stringify(defaultCounterConfig)};
 const defaultLoaderConfig = ${JSON.stringify(defaultLoaderConfig)};
+const defaultStatusConfig = ${JSON.stringify(defaultStatusConfig)};
 
 const style = document.createElement("style");
 style.dataset.denof = "counter-embed";
@@ -33,6 +41,14 @@ style.textContent = \`
   .denof-loader__button:disabled { opacity: 0.6; cursor: not-allowed; }
   .denof-loader__status { margin: 8px 0 0; font-size: 14px; color: #0ea5e9; }
   .denof-loader__error { margin: 8px 0 0; font-size: 14px; color: #dc2626; }
+  .denof-status { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; border: 1px solid #e2e8f0; border-radius: 12px; padding: 14px 16px; max-width: 360px; background: white; box-shadow: 0 12px 34px rgba(0, 0, 0, 0.06); display: grid; gap: 8px; }
+  .denof-status__meta { display: flex; align-items: center; gap: 10px; }
+  .denof-status__dot { width: 12px; height: 12px; border-radius: 999px; background: #22c55e; box-shadow: 0 0 0 6px rgba(34, 197, 94, 0.12); transition: background 120ms ease, box-shadow 120ms ease; }
+  .denof-status__label { margin: 0; font-weight: 800; color: #0f172a; }
+  .denof-status__detail { margin: 0; color: #475569; }
+  .denof-status__refresh { width: fit-content; background: #0f172a; color: white; border: none; padding: 8px 12px; border-radius: 10px; font-weight: 700; cursor: pointer; transition: transform 150ms ease, box-shadow 150ms ease; }
+  .denof-status__refresh:hover { transform: translateY(-1px); box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25); }
+  .denof-status__timestamp { font-size: 13px; color: #0ea5e9; margin: 0; }
 \`;
 if (!document.querySelector('style[data-denof="counter-embed"]')) {
   document.head.appendChild(style);
@@ -79,6 +95,25 @@ const applyLoaderData = (target) => {
   return enriched;
 };
 
+const applyStatusData = (target) => {
+  const enriched = { ...defaultStatusConfig };
+
+  if (target.dataset.payload) {
+    try {
+      Object.assign(enriched, JSON.parse(target.dataset.payload));
+    } catch (err) {
+      console.warn("Neplatný JSON v data-payload", err);
+    }
+  }
+
+  if (target.dataset.label) enriched.label = target.dataset.label;
+  if (target.dataset.status) enriched.status = target.dataset.status;
+  if (target.dataset.detail) enriched.detail = target.dataset.detail;
+  if (target.dataset.tone) enriched.tone = target.dataset.tone;
+
+  return enriched;
+};
+
 const Counter = ({ label, start }) => {
   const [count, setCount] = useState(start);
 
@@ -97,7 +132,7 @@ const Counter = ({ label, start }) => {
   ]);
 };
 
-const mountAll = () => {
+const mountCounters = () => {
   const targets = document.querySelectorAll('[data-denof-embed="counter"]');
   targets.forEach((target) => {
     const data = applyCounterData(target);
@@ -171,14 +206,66 @@ const mountLazyLoaders = () => {
   });
 };
 
+const toneStyles = {
+  success: { dot: "#22c55e", shadow: "rgba(34, 197, 94, 0.12)" },
+  warning: { dot: "#f59e0b", shadow: "rgba(245, 158, 11, 0.18)" },
+  danger: { dot: "#ef4444", shadow: "rgba(239, 68, 68, 0.18)" },
+};
+
+const StatusCard = ({ label, status, detail, tone }) => {
+  const [timestamp, setTimestamp] = useState(new Date());
+  const toneStyle = toneStyles[tone] || toneStyles.success;
+
+  useEffect(() => {
+    const id = setInterval(() => setTimestamp(new Date()), 4000);
+    return () => clearInterval(id);
+  }, []);
+
+  return h("div", { class: "denof-status" }, [
+    h("div", { class: "denof-status__meta" }, [
+      h("span", {
+        class: "denof-status__dot",
+        style: `background:${toneStyle.dot}; box-shadow: 0 0 0 6px ${toneStyle.shadow};`,
+        role: "presentation",
+      }),
+      h("p", { class: "denof-status__label" }, `${label}: ${status}`),
+    ]),
+    h("p", { class: "denof-status__detail" }, detail),
+    h(
+      "button",
+      {
+        class: "denof-status__refresh",
+        type: "button",
+        onClick: () => setTimestamp(new Date()),
+      },
+      "Aktualizovat stav"
+    ),
+    h(
+      "p",
+      { class: "denof-status__timestamp", role: "status", "aria-live": "polite" },
+      `Naposledy zkontrolováno ${timestamp.toLocaleTimeString("cs-CZ")}`
+    ),
+  ]);
+};
+
+const mountStatusCards = () => {
+  const targets = document.querySelectorAll('[data-denof-embed="status"]');
+  targets.forEach((target) => {
+    const data = applyStatusData(target);
+    render(h(StatusCard, data), target);
+  });
+};
+
 if (document.readyState === "loading") {
   document.addEventListener("DOMContentLoaded", () => {
-    mountAll();
+    mountCounters();
     mountLazyLoaders();
+    mountStatusCards();
   });
 } else {
-  mountAll();
+  mountCounters();
   mountLazyLoaders();
+  mountStatusCards();
 }
 `;
 

--- a/routes/embed/product.ts
+++ b/routes/embed/product.ts
@@ -1,16 +1,23 @@
 import { Handlers } from "$fresh/server.ts";
 
-const defaultConfig = {
+const defaultCounterConfig = {
   label: "Klikni na mě",
   start: 0,
+};
+
+const defaultLoaderConfig = {
+  buttonLabel: "Načíst mini aplikaci",
+  loadedLabel: "Aplikace načtena",
+  loadSrc: "/embed/lazy-app",
 };
 
 export const handler: Handlers = {
   GET() {
     const script = `import { h, render } from "https://esm.sh/preact@10.22.0";
-import { useState } from "https://esm.sh/preact@10.22.0/hooks";
+import { useRef, useState } from "https://esm.sh/preact@10.22.0/hooks";
 
-const defaultConfig = ${JSON.stringify(defaultConfig)};
+const defaultCounterConfig = ${JSON.stringify(defaultCounterConfig)};
+const defaultLoaderConfig = ${JSON.stringify(defaultLoaderConfig)};
 
 const style = document.createElement("style");
 style.dataset.denof = "counter-embed";
@@ -20,6 +27,12 @@ style.textContent = \`
   .denof-counter__value { display: inline-flex; align-items: center; gap: 8px; margin: 0 0 12px; color: #111827; font-weight: 700; font-size: 18px; }
   .denof-counter__button { background: linear-gradient(90deg, #0ea5e9, #6366f1); color: white; border: none; padding: 10px 14px; border-radius: 10px; font-weight: 700; cursor: pointer; transition: transform 150ms ease, box-shadow 150ms ease; }
   .denof-counter__button:hover { transform: translateY(-1px); box-shadow: 0 14px 32px rgba(59, 130, 246, 0.35); }
+  .denof-loader { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; border: 1px dashed #cbd5e1; border-radius: 12px; padding: 14px 16px; max-width: 360px; background: #f8fafc; color: #0f172a; }
+  .denof-loader__button { background: #0f172a; color: white; border: none; padding: 10px 14px; border-radius: 10px; font-weight: 700; cursor: pointer; transition: transform 150ms ease, box-shadow 150ms ease; }
+  .denof-loader__button:hover { transform: translateY(-1px); box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25); }
+  .denof-loader__button:disabled { opacity: 0.6; cursor: not-allowed; }
+  .denof-loader__status { margin: 8px 0 0; font-size: 14px; color: #0ea5e9; }
+  .denof-loader__error { margin: 8px 0 0; font-size: 14px; color: #dc2626; }
 \`;
 if (!document.querySelector('style[data-denof="counter-embed"]')) {
   document.head.appendChild(style);
@@ -30,8 +43,8 @@ const parseNumber = (value, fallback) => {
   return Number.isFinite(parsed) ? parsed : fallback;
 };
 
-const applyData = (target) => {
-  const enriched = { ...defaultConfig };
+const applyCounterData = (target) => {
+  const enriched = { ...defaultCounterConfig };
 
   if (target.dataset.payload) {
     try {
@@ -44,6 +57,24 @@ const applyData = (target) => {
   if (target.dataset.label) enriched.label = target.dataset.label;
   if (target.dataset.start)
     enriched.start = parseNumber(target.dataset.start, enriched.start);
+
+  return enriched;
+};
+
+const applyLoaderData = (target) => {
+  const enriched = { ...defaultLoaderConfig };
+
+  if (target.dataset.payload) {
+    try {
+      Object.assign(enriched, JSON.parse(target.dataset.payload));
+    } catch (err) {
+      console.warn("Neplatný JSON v data-payload", err);
+    }
+  }
+
+  if (target.dataset.buttonLabel) enriched.buttonLabel = target.dataset.buttonLabel;
+  if (target.dataset.loadedLabel) enriched.loadedLabel = target.dataset.loadedLabel;
+  if (target.dataset.loadSrc) enriched.loadSrc = target.dataset.loadSrc;
 
   return enriched;
 };
@@ -69,15 +100,85 @@ const Counter = ({ label, start }) => {
 const mountAll = () => {
   const targets = document.querySelectorAll('[data-denof-embed="counter"]');
   targets.forEach((target) => {
-    const data = applyData(target);
+    const data = applyCounterData(target);
     render(h(Counter, data), target);
   });
 };
 
+const LazyLoader = ({ buttonLabel, loadedLabel, loadSrc }) => {
+  const [state, setState] = useState("idle");
+  const [error, setError] = useState("");
+  const containerRef = useRef(null);
+
+  const handleClick = async () => {
+    if (state !== "idle") return;
+    setState("loading");
+    try {
+      const target = containerRef.current;
+      if (!target) throw new Error("Cílový element není připraven");
+      const module = await import(loadSrc);
+      const mount = module.default || module.mountLazyApp;
+      if (typeof mount !== "function") {
+        throw new Error("Chybí funkce mountLazyApp");
+      }
+      await mount(target);
+      setState("done");
+    } catch (err) {
+      console.error("Nepodařilo se načíst aplikaci", err);
+      setError("Nepodařilo se načíst aplikaci. Zkuste to prosím znovu.");
+      setState("error");
+    }
+  };
+
+  return h("div", { class: "denof-loader" }, [
+    h("div", { ref: containerRef }),
+    state === "idle"
+      ? h(
+          "button",
+          { class: "denof-loader__button", type: "button", onClick: handleClick },
+          buttonLabel
+        )
+      : null,
+    state === "loading"
+      ? h(
+          "button",
+          { class: "denof-loader__button", type: "button", disabled: true },
+          "Načítám…"
+        )
+      : null,
+    state === "done"
+      ? h(
+          "p",
+          { class: "denof-loader__status", role: "status", "aria-live": "polite" },
+          loadedLabel
+        )
+      : null,
+    state === "error"
+      ? h(
+          "p",
+          { class: "denof-loader__error", role: "alert" },
+          error || "Chyba při načítání."
+        )
+      : null,
+  ]);
+};
+
+const mountLazyLoaders = () => {
+  const targets = document.querySelectorAll('[data-denof-embed="loader"]');
+  targets.forEach((target) => {
+    const data = applyLoaderData(target);
+    render(h(LazyLoader, data), target);
+  });
+};
+
 if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", mountAll);
+  document.addEventListener("DOMContentLoaded", () => {
+    mountAll();
+    mountLazyLoaders();
+  });
 } else {
   mountAll();
+  mountLazyLoaders();
 }
 `;
 

--- a/routes/embed/product.ts
+++ b/routes/embed/product.ts
@@ -53,7 +53,7 @@ const Counter = ({ label, start }) => {
 
   return h("div", { class: "denof-counter" }, [
     h("p", { class: "denof-counter__label" }, label),
-    h("p", { class: "denof-counter__value", role: "status", "aria-live": "polite" }, `Počítadlo: ${count}`),
+    h("p", { class: "denof-counter__value", role: "status", "aria-live": "polite" }, `Počítadlo: \${count}`),
     h(
       "button",
       { class: "denof-counter__button", type: "button", onClick: () => setCount((value) => value + 1) },

--- a/routes/embed/product.ts
+++ b/routes/embed/product.ts
@@ -14,13 +14,13 @@ const defaultConfig = ${JSON.stringify(defaultConfig)};
 
 const style = document.createElement("style");
 style.dataset.denof = "counter-embed";
-style.textContent = `
+style.textContent = \`
   .denof-counter { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; border: 1px solid #e5e7eb; border-radius: 12px; padding: 14px 16px; max-width: 280px; background: white; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.07); }
   .denof-counter__label { margin: 0 0 10px; color: #0f172a; font-weight: 700; font-size: 16px; }
   .denof-counter__value { display: inline-flex; align-items: center; gap: 8px; margin: 0 0 12px; color: #111827; font-weight: 700; font-size: 18px; }
   .denof-counter__button { background: linear-gradient(90deg, #0ea5e9, #6366f1); color: white; border: none; padding: 10px 14px; border-radius: 10px; font-weight: 700; cursor: pointer; transition: transform 150ms ease, box-shadow 150ms ease; }
   .denof-counter__button:hover { transform: translateY(-1px); box-shadow: 0 14px 32px rgba(59, 130, 246, 0.35); }
-`;
+\`;
 if (!document.querySelector('style[data-denof="counter-embed"]')) {
   document.head.appendChild(style);
 }
@@ -53,7 +53,7 @@ const Counter = ({ label, start }) => {
 
   return h("div", { class: "denof-counter" }, [
     h("p", { class: "denof-counter__label" }, label),
-    h("p", { class: "denof-counter__value", role: "status", "aria-live": "polite" }, `Počítadlo: \${count}`),
+    h("p", { class: "denof-counter__value", role: "status", "aria-live": "polite" }, \`Počítadlo: \\${count}\`),
     h(
       "button",
       { class: "denof-counter__button", type: "button", onClick: () => setCount((value) => value + 1) },

--- a/routes/embed/product.ts
+++ b/routes/embed/product.ts
@@ -21,16 +21,7 @@ const defaultStatusConfig = {
 
 export const handler: Handlers = {
   GET() {
-    const script = String.raw`import { h, render } from "https://esm.sh/preact@10.22.0";
-import { useEffect, useRef, useState } from "https://esm.sh/preact@10.22.0/hooks";
-
-const defaultCounterConfig = ${JSON.stringify(defaultCounterConfig)};
-const defaultLoaderConfig = ${JSON.stringify(defaultLoaderConfig)};
-const defaultStatusConfig = ${JSON.stringify(defaultStatusConfig)};
-
-const style = document.createElement("style");
-style.dataset.denof = "counter-embed";
-style.textContent = `
+    const styles = String.raw`
   .denof-counter { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; border: 1px solid #e5e7eb; border-radius: 12px; padding: 14px 16px; max-width: 280px; background: white; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.07); }
   .denof-counter__label { margin: 0 0 10px; color: #0f172a; font-weight: 700; font-size: 16px; }
   .denof-counter__value { display: inline-flex; align-items: center; gap: 8px; margin: 0 0 12px; color: #111827; font-weight: 700; font-size: 18px; }
@@ -51,6 +42,18 @@ style.textContent = `
   .denof-status__refresh:hover { transform: translateY(-1px); box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25); }
   .denof-status__timestamp { font-size: 13px; color: #0ea5e9; margin: 0; }
 `;
+
+    const script = String.raw`import { h, render } from "https://esm.sh/preact@10.22.0";
+import { useEffect, useRef, useState } from "https://esm.sh/preact@10.22.0/hooks";
+
+const defaultCounterConfig = ${JSON.stringify(defaultCounterConfig)};
+const defaultLoaderConfig = ${JSON.stringify(defaultLoaderConfig)};
+const defaultStatusConfig = ${JSON.stringify(defaultStatusConfig)};
+const styleContent = ${JSON.stringify(styles)};
+
+const style = document.createElement("style");
+style.dataset.denof = "counter-embed";
+style.textContent = styleContent;
 if (!document.querySelector('style[data-denof="counter-embed"]')) {
   document.head.appendChild(style);
 }
@@ -122,7 +125,7 @@ const Counter = ({ label, start }) => {
     h(
       "p",
       { class: "denof-counter__value", role: "status", "aria-live": "polite" },
-      `Počítadlo: ${"${count}"}`
+      "Počítadlo: " + count
     ),
     h(
       "button",
@@ -225,10 +228,10 @@ const StatusCard = ({ label, status, detail, tone }) => {
     h("div", { class: "denof-status__meta" }, [
       h("span", {
         class: "denof-status__dot",
-        style: `background:${toneStyle.dot}; box-shadow: 0 0 0 6px ${toneStyle.shadow};`,
+        style: "background:" + toneStyle.dot + "; box-shadow: 0 0 0 6px " + toneStyle.shadow + ";",
         role: "presentation",
       }),
-      h("p", { class: "denof-status__label" }, `${label}: ${status}`),
+      h("p", { class: "denof-status__label" }, label + ": " + status),
     ]),
     h("p", { class: "denof-status__detail" }, detail),
     h(
@@ -243,7 +246,7 @@ const StatusCard = ({ label, status, detail, tone }) => {
     h(
       "p",
       { class: "denof-status__timestamp", role: "status", "aria-live": "polite" },
-      `Naposledy zkontrolováno ${"${timestamp.toLocaleTimeString(\"cs-CZ\")}"}`
+      "Naposledy zkontrolováno " + timestamp.toLocaleTimeString("cs-CZ")
     ),
   ]);
 };

--- a/routes/embed/product.ts
+++ b/routes/embed/product.ts
@@ -1,9 +1,9 @@
-
 import { Handlers } from "$fresh/server.ts";
 
 const defaultCounterConfig = {
   label: "Klikni na mě",
   start: 0,
+  broadcast: true,
 };
 
 const defaultLoaderConfig = {
@@ -17,6 +17,13 @@ const defaultStatusConfig = {
   status: "Online",
   detail: "Vše běží hladce",
   tone: "success",
+  listenToEvents: true,
+};
+
+const defaultShellConfig = {
+  heading: "Denof UI embed shell",
+  description:
+    "Hlavní Preact kontejner, který sdílí stav mezi komponentami a je připravený pro SSR.",
 };
 
 export const handler: Handlers = {
@@ -41,6 +48,11 @@ export const handler: Handlers = {
   .denof-status__refresh { width: fit-content; background: #0f172a; color: white; border: none; padding: 8px 12px; border-radius: 10px; font-weight: 700; cursor: pointer; transition: transform 150ms ease, box-shadow 150ms ease; }
   .denof-status__refresh:hover { transform: translateY(-1px); box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25); }
   .denof-status__timestamp { font-size: 13px; color: #0ea5e9; margin: 0; }
+  .denof-shell { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; border: 1px solid #e2e8f0; border-radius: 16px; padding: 18px; background: linear-gradient(180deg, #f8fafc, #ffffff); box-shadow: 0 18px 42px rgba(15, 23, 42, 0.08); display: grid; gap: 14px; max-width: 720px; }
+  .denof-shell__header { display: flex; flex-direction: column; gap: 6px; }
+  .denof-shell__title { margin: 0; font-size: 18px; font-weight: 800; color: #0f172a; }
+  .denof-shell__desc { margin: 0; color: #475569; }
+  .denof-shell__grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
 `;
 
     const script = String.raw`import { h, render } from "https://esm.sh/preact@10.22.0";
@@ -49,6 +61,7 @@ import { useEffect, useRef, useState } from "https://esm.sh/preact@10.22.0/hooks
 const defaultCounterConfig = ${JSON.stringify(defaultCounterConfig)};
 const defaultLoaderConfig = ${JSON.stringify(defaultLoaderConfig)};
 const defaultStatusConfig = ${JSON.stringify(defaultStatusConfig)};
+const defaultShellConfig = ${JSON.stringify(defaultShellConfig)};
 const styleContent = ${JSON.stringify(styles)};
 
 const style = document.createElement("style");
@@ -57,6 +70,8 @@ style.textContent = styleContent;
 if (!document.querySelector('style[data-denof="counter-embed"]')) {
   document.head.appendChild(style);
 }
+
+const bus = (window.__denofEmbedBus = window.__denofEmbedBus || new EventTarget());
 
 const parseNumber = (value, fallback) => {
   const parsed = Number(value);
@@ -76,6 +91,7 @@ const applyCounterData = (target) => {
 
   if (target.dataset.label) enriched.label = target.dataset.label;
   if (target.dataset.start) enriched.start = parseNumber(target.dataset.start, enriched.start);
+  if (target.dataset.broadcast === "false") enriched.broadcast = false;
 
   return enriched;
 };
@@ -113,12 +129,45 @@ const applyStatusData = (target) => {
   if (target.dataset.status) enriched.status = target.dataset.status;
   if (target.dataset.detail) enriched.detail = target.dataset.detail;
   if (target.dataset.tone) enriched.tone = target.dataset.tone;
+  if (target.dataset.listenToEvents === "false") enriched.listenToEvents = false;
 
   return enriched;
 };
 
-const Counter = ({ label, start }) => {
+const applyShellData = (target) => {
+  const enriched = {
+    ...defaultShellConfig,
+    counter: { ...defaultCounterConfig },
+    status: { ...defaultStatusConfig },
+    loader: { ...defaultLoaderConfig },
+  };
+
+  if (target.dataset.payload) {
+    try {
+      Object.assign(enriched, JSON.parse(target.dataset.payload));
+    } catch (err) {
+      console.warn("Neplatný JSON v data-payload", err);
+    }
+  }
+
+  if (target.dataset.heading) enriched.heading = target.dataset.heading;
+  if (target.dataset.description) enriched.description = target.dataset.description;
+
+  enriched.counter = applyCounterData(target);
+  enriched.status = applyStatusData(target);
+  enriched.loader = applyLoaderData(target);
+
+  return enriched;
+};
+
+const Counter = ({ label, start, broadcast = true, onChange }) => {
   const [count, setCount] = useState(start);
+
+  const update = (next) => {
+    setCount(next);
+    if (broadcast) bus.dispatchEvent(new CustomEvent("denof:count", { detail: { count: next } }));
+    if (typeof onChange === "function") onChange(next);
+  };
 
   return h("div", { class: "denof-counter" }, [
     h("p", { class: "denof-counter__label" }, label),
@@ -129,7 +178,7 @@ const Counter = ({ label, start }) => {
     ),
     h(
       "button",
-      { class: "denof-counter__button", type: "button", onClick: () => setCount((value) => value + 1) },
+      { class: "denof-counter__button", type: "button", onClick: () => update((count || 0) + 1) },
       "Přidat klik"
     ),
   ]);
@@ -160,6 +209,7 @@ const LazyLoader = ({ buttonLabel, loadedLabel, loadSrc }) => {
         throw new Error("Chybí funkce mountLazyApp");
       }
       await mount(target);
+      bus.dispatchEvent(new CustomEvent("denof:lazy-loaded", { detail: { source: loadSrc } }));
       setState("done");
     } catch (err) {
       console.error("Nepodařilo se načíst aplikaci", err);
@@ -215,14 +265,39 @@ const toneStyles = {
   danger: { dot: "#ef4444", shadow: "rgba(239, 68, 68, 0.18)" },
 };
 
-const StatusCard = ({ label, status, detail, tone }) => {
+const StatusCard = ({ label, status, detail, tone, listenToEvents = true }) => {
   const [timestamp, setTimestamp] = useState(new Date());
-  const toneStyle = toneStyles[tone] || toneStyles.success;
+  const [currentDetail, setCurrentDetail] = useState(detail);
+  const [currentTone, setCurrentTone] = useState(tone);
+  const toneStyle = toneStyles[currentTone] || toneStyles.success;
 
   useEffect(() => {
     const id = setInterval(() => setTimestamp(new Date()), 4000);
     return () => clearInterval(id);
   }, []);
+
+  useEffect(() => {
+    if (!listenToEvents) return;
+
+    const handleCount = (event) => {
+      const next = event?.detail?.count ?? 0;
+      setCurrentDetail("Celkem " + next + " kliků");
+      setCurrentTone(next > 10 ? "warning" : "success");
+    };
+
+    const handleLazy = (event) => {
+      const src = event?.detail?.source || "";
+      setCurrentDetail("Načtena lazy aplikace z " + src);
+      setCurrentTone("success");
+    };
+
+    bus.addEventListener("denof:count", handleCount);
+    bus.addEventListener("denof:lazy-loaded", handleLazy);
+    return () => {
+      bus.removeEventListener("denof:count", handleCount);
+      bus.removeEventListener("denof:lazy-loaded", handleLazy);
+    };
+  }, [listenToEvents]);
 
   return h("div", { class: "denof-status" }, [
     h("div", { class: "denof-status__meta" }, [
@@ -233,7 +308,7 @@ const StatusCard = ({ label, status, detail, tone }) => {
       }),
       h("p", { class: "denof-status__label" }, label + ": " + status),
     ]),
-    h("p", { class: "denof-status__detail" }, detail),
+    h("p", { class: "denof-status__detail" }, currentDetail),
     h(
       "button",
       {
@@ -259,16 +334,61 @@ const mountStatusCards = () => {
   });
 };
 
-if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", () => {
-    mountCounters();
-    mountLazyLoaders();
-    mountStatusCards();
+const Shell = ({ heading, description, counter, status, loader }) => {
+  const [sharedCount, setSharedCount] = useState(counter.start);
+  const [lazyLoaded, setLazyLoaded] = useState(false);
+
+  useEffect(() => {
+    const handleCount = (event) => setSharedCount(event?.detail?.count ?? 0);
+    const handleLazy = () => setLazyLoaded(true);
+    bus.addEventListener("denof:count", handleCount);
+    bus.addEventListener("denof:lazy-loaded", handleLazy);
+    return () => {
+      bus.removeEventListener("denof:count", handleCount);
+      bus.removeEventListener("denof:lazy-loaded", handleLazy);
+    };
+  }, []);
+
+  return h("div", { class: "denof-shell" }, [
+    h("div", { class: "denof-shell__header" }, [
+      h("p", { class: "denof-shell__title" }, heading),
+      h("p", { class: "denof-shell__desc" }, description),
+    ]),
+    h("div", { class: "denof-shell__grid" }, [
+      h(Counter, {
+        ...counter,
+        onChange: setSharedCount,
+        start: sharedCount,
+      }),
+      h(StatusCard, {
+        ...status,
+        detail: lazyLoaded ? "Lazy modul je načten" : status.detail,
+        listenToEvents: true,
+      }),
+      h(LazyLoader, loader),
+    ]),
+  ]);
+};
+
+const mountShells = () => {
+  const targets = document.querySelectorAll('[data-denof-embed="shell"]');
+  targets.forEach((target) => {
+    const data = applyShellData(target);
+    render(h(Shell, data), target);
   });
-} else {
+};
+
+const mountAll = () => {
   mountCounters();
   mountLazyLoaders();
   mountStatusCards();
+  mountShells();
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", () => mountAll());
+} else {
+  mountAll();
 }
 `;
 

--- a/routes/embed/product.ts
+++ b/routes/embed/product.ts
@@ -1,3 +1,4 @@
+
 import { Handlers } from "$fresh/server.ts";
 
 const defaultCounterConfig = {
@@ -20,7 +21,7 @@ const defaultStatusConfig = {
 
 export const handler: Handlers = {
   GET() {
-    const script = `import { h, render } from "https://esm.sh/preact@10.22.0";
+    const script = String.raw`import { h, render } from "https://esm.sh/preact@10.22.0";
 import { useEffect, useRef, useState } from "https://esm.sh/preact@10.22.0/hooks";
 
 const defaultCounterConfig = ${JSON.stringify(defaultCounterConfig)};
@@ -29,7 +30,7 @@ const defaultStatusConfig = ${JSON.stringify(defaultStatusConfig)};
 
 const style = document.createElement("style");
 style.dataset.denof = "counter-embed";
-style.textContent = \`
+style.textContent = `
   .denof-counter { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; border: 1px solid #e5e7eb; border-radius: 12px; padding: 14px 16px; max-width: 280px; background: white; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.07); }
   .denof-counter__label { margin: 0 0 10px; color: #0f172a; font-weight: 700; font-size: 16px; }
   .denof-counter__value { display: inline-flex; align-items: center; gap: 8px; margin: 0 0 12px; color: #111827; font-weight: 700; font-size: 18px; }
@@ -49,7 +50,7 @@ style.textContent = \`
   .denof-status__refresh { width: fit-content; background: #0f172a; color: white; border: none; padding: 8px 12px; border-radius: 10px; font-weight: 700; cursor: pointer; transition: transform 150ms ease, box-shadow 150ms ease; }
   .denof-status__refresh:hover { transform: translateY(-1px); box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25); }
   .denof-status__timestamp { font-size: 13px; color: #0ea5e9; margin: 0; }
-\`;
+`;
 if (!document.querySelector('style[data-denof="counter-embed"]')) {
   document.head.appendChild(style);
 }
@@ -71,8 +72,7 @@ const applyCounterData = (target) => {
   }
 
   if (target.dataset.label) enriched.label = target.dataset.label;
-  if (target.dataset.start)
-    enriched.start = parseNumber(target.dataset.start, enriched.start);
+  if (target.dataset.start) enriched.start = parseNumber(target.dataset.start, enriched.start);
 
   return enriched;
 };
@@ -122,7 +122,7 @@ const Counter = ({ label, start }) => {
     h(
       "p",
       { class: "denof-counter__value", role: "status", "aria-live": "polite" },
-      \`Počítadlo: ${"${count}"}\`
+      `Počítadlo: ${"${count}"}`
     ),
     h(
       "button",
@@ -243,7 +243,7 @@ const StatusCard = ({ label, status, detail, tone }) => {
     h(
       "p",
       { class: "denof-status__timestamp", role: "status", "aria-live": "polite" },
-      `Naposledy zkontrolováno ${timestamp.toLocaleTimeString("cs-CZ")}`
+      `Naposledy zkontrolováno ${"${timestamp.toLocaleTimeString(\"cs-CZ\")}"}`
     ),
   ]);
 };


### PR DESCRIPTION
## Summary
- add an embeddable Preact product card script served from `/embed/product`
- create an `/embed` page with copy-paste instructions and live preview

## Testing
- deno fmt routes/embed/product.ts routes/embed/index.tsx *(fails: deno not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921b29c271c8323af8210fe45a43f65)