### PR TITLE
Add Nuxt embed SSR example with demo server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.nuxt
+.output
+.nitro
+.DS_Store

--- a/nuxt-embed-example/README.md
+++ b/nuxt-embed-example/README.md
@@ -1,0 +1,36 @@
+# Nuxt embed example
+
+Tento příklad ukazuje architekturu, kde Nuxt 3 slouží jako render engine a externí server (Node/PHP) dodává payload, který se rendruje na HTML.
+
+## Struktura
+- `components/bridge/PageBridge.vue` – vstupní bod, který přijme payload a vykreslí bloky v základním layoutu.
+- `components/blocks/*` – jednotlivé bloky (hero, product list) a `BlockRenderer` jako přepínač podle `block.type`.
+- `server/routes/render-page.post.ts` – endpoint pro payload → HTML.
+- `server/routes/render-block.get.ts` – endpoint pro vykreslení jedné komponenty podle dotazu.
+- `server/api/page-home.get.ts` + `pages/index.vue` – čistý Nuxt SSR scénář.
+- `demo-server` – ukázkový Node server, který simuluje PHP: pošle payload na Nuxt a vloží HTML do své stránky.
+
+## Spuštění
+1. **Nuxt dev server**
+   ```bash
+   cd nuxt-embed-example
+   npm install
+   npm run dev
+   ```
+   Běží na http://localhost:3000.
+
+2. **Node demo server**
+   ```bash
+   cd nuxt-embed-example/demo-server
+   npm install
+   npm start
+   ```
+   Běží na http://localhost:4000.
+
+## Endpoints
+- `POST http://localhost:3000/render-page` s tělem `{ "payload": {...} }` vrátí `{ html }` pro celou stránku.
+- `GET http://localhost:3000/render-block?component=hero&props=...` vrátí HTML fragment pro jeden blok.
+- `http://localhost:4000/` – Node server → Nuxt `/render-page` → vlastní šablona.
+- `http://localhost:4000/hero-demo` – Node server → Nuxt `/render-block` → vlastní šablona.
+
+Když později vyměníš Node za PHP, stačí dodržet stejný payload a volat stejné Nuxt endpointy.

--- a/nuxt-embed-example/app.vue
+++ b/nuxt-embed-example/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/nuxt-embed-example/assets/styles.css
+++ b/nuxt-embed-example/assets/styles.css
@@ -1,0 +1,104 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  background-color: #f8fafc;
+}
+
+a {
+  color: #0f172a;
+}
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: white;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.08);
+}
+
+.header,
+.footer {
+  padding: 16px 24px;
+  background: #0f172a;
+  color: white;
+}
+
+.menu {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.menu-item {
+  color: white;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.user {
+  margin-left: auto;
+  font-weight: 500;
+}
+
+.content {
+  flex: 1;
+  padding: 32px 24px 48px;
+}
+
+.hero {
+  padding: 32px;
+  border-radius: 16px;
+  background: linear-gradient(120deg, #2563eb, #0ea5e9);
+  color: white;
+  margin-bottom: 24px;
+  box-shadow: 0 10px 40px rgba(14, 165, 233, 0.35);
+}
+
+.hero .title {
+  margin: 0;
+  font-size: 32px;
+}
+
+.hero .subtitle {
+  margin: 12px 0 0;
+  font-size: 18px;
+  opacity: 0.95;
+}
+
+.products {
+  background: #f1f5f9;
+  padding: 24px;
+  border-radius: 16px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 4px 20px rgba(15, 23, 42, 0.08);
+}
+
+.products .title {
+  margin: 0 0 12px;
+  font-size: 22px;
+}
+
+.products .list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.products .item {
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: white;
+  box-shadow: 0 2px 10px rgba(15, 23, 42, 0.05);
+}
+
+.products .price {
+  font-weight: 700;
+}

--- a/nuxt-embed-example/components/blocks/BlockRenderer.vue
+++ b/nuxt-embed-example/components/blocks/BlockRenderer.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import HeroBlock from '~/components/blocks/HeroBlock.vue'
+import ProductListBlock from '~/components/blocks/ProductListBlock.vue'
+
+type Block = {
+  type: string
+  props?: Record<string, any>
+}
+
+const props = defineProps<{
+  blocks: Block[]
+}>()
+
+function resolveBlock(type: string) {
+  switch (type) {
+    case 'hero':
+      return HeroBlock
+    case 'productList':
+      return ProductListBlock
+    default:
+      return null
+  }
+}
+</script>
+
+<template>
+  <div>
+    <component
+      v-for="(block, index) in blocks"
+      :key="index"
+      :is="resolveBlock(block.type)"
+      v-bind="block.props"
+      v-if="resolveBlock(block.type)"
+    />
+  </div>
+</template>

--- a/nuxt-embed-example/components/blocks/BlockRenderer.vue
+++ b/nuxt-embed-example/components/blocks/BlockRenderer.vue
@@ -9,18 +9,20 @@ type Block = {
   props?: Record<string, any>
 }
 
-const props = withDefaults(defineProps<{
-  blocks?: Block[]
-}>(), {
-  blocks: () => []
-})
+const props = defineProps<{
+  blocks?: unknown
+}>()
 
-const safeBlocks = computed(() =>
-  (props.blocks || []).filter(
+const safeBlocks = computed(() => {
+  if (!Array.isArray(props.blocks)) {
+    return [] as Block[]
+  }
+
+  return props.blocks.filter(
     (block): block is Block =>
       Boolean(block) && typeof (block as Block).type === 'string'
   )
-)
+})
 
 function resolveBlock(type: string) {
   switch (type) {

--- a/nuxt-embed-example/components/blocks/BlockRenderer.vue
+++ b/nuxt-embed-example/components/blocks/BlockRenderer.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import HeroBlock from '~/components/blocks/HeroBlock.vue'
 import ProductListBlock from '~/components/blocks/ProductListBlock.vue'
 
@@ -7,9 +9,18 @@ type Block = {
   props?: Record<string, any>
 }
 
-const props = defineProps<{
-  blocks: Block[]
-}>()
+const props = withDefaults(defineProps<{
+  blocks?: Block[]
+}>(), {
+  blocks: () => []
+})
+
+const safeBlocks = computed(() =>
+  (props.blocks || []).filter(
+    (block): block is Block =>
+      Boolean(block) && typeof (block as Block).type === 'string'
+  )
+)
 
 function resolveBlock(type: string) {
   switch (type) {
@@ -26,7 +37,7 @@ function resolveBlock(type: string) {
 <template>
   <div>
     <component
-      v-for="(block, index) in blocks"
+      v-for="(block, index) in safeBlocks"
       :key="index"
       :is="resolveBlock(block.type)"
       v-bind="block.props"

--- a/nuxt-embed-example/components/blocks/HeroBlock.vue
+++ b/nuxt-embed-example/components/blocks/HeroBlock.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+const props = defineProps<{
+  title: string
+  subtitle?: string
+}>()
+</script>
+
+<template>
+  <section class="hero">
+    <h1 class="title">{{ title }}</h1>
+    <p v-if="subtitle" class="subtitle">{{ subtitle }}</p>
+  </section>
+</template>

--- a/nuxt-embed-example/components/blocks/ProductListBlock.vue
+++ b/nuxt-embed-example/components/blocks/ProductListBlock.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+const props = defineProps<{
+  title?: string
+  items: Array<{ name: string; price: number }>
+}>()
+</script>
+
+<template>
+  <section class="products">
+    <h2 v-if="title" class="title">{{ title }}</h2>
+    <ul class="list">
+      <li v-for="item in items" :key="item.name" class="item">
+        <span>{{ item.name }}</span>
+        <span class="price">{{ item.price }} Kč</span>
+      </li>
+    </ul>
+  </section>
+</template>

--- a/nuxt-embed-example/components/bridge/PageBridge.vue
+++ b/nuxt-embed-example/components/bridge/PageBridge.vue
@@ -2,14 +2,16 @@
 import LayoutBase from '~/components/layout/LayoutBase.vue'
 import BlockRenderer from '~/components/blocks/BlockRenderer.vue'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   menu?: Array<{ label: string; url: string }>
   user?: { name?: string | null }
-  blocks: Array<{
+  blocks?: Array<{
     type: string
     props?: Record<string, any>
   }>
-}>()
+}>(), {
+  blocks: () => []
+})
 </script>
 
 <template>

--- a/nuxt-embed-example/components/bridge/PageBridge.vue
+++ b/nuxt-embed-example/components/bridge/PageBridge.vue
@@ -1,21 +1,20 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import LayoutBase from '~/components/layout/LayoutBase.vue'
 import BlockRenderer from '~/components/blocks/BlockRenderer.vue'
 
-const props = withDefaults(defineProps<{
+const props = defineProps<{
   menu?: Array<{ label: string; url: string }>
   user?: { name?: string | null }
-  blocks?: Array<{
-    type: string
-    props?: Record<string, any>
-  }>
-}>(), {
-  blocks: () => []
-})
+  blocks?: unknown
+}>()
+
+const safeBlocks = computed(() => (Array.isArray(props.blocks) ? props.blocks : []))
 </script>
 
 <template>
   <LayoutBase :menu="menu" :user="user">
-    <BlockRenderer :blocks="blocks" />
+    <BlockRenderer :blocks="safeBlocks" />
   </LayoutBase>
 </template>

--- a/nuxt-embed-example/components/bridge/PageBridge.vue
+++ b/nuxt-embed-example/components/bridge/PageBridge.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import LayoutBase from '~/components/layout/LayoutBase.vue'
+import BlockRenderer from '~/components/blocks/BlockRenderer.vue'
+
+const props = defineProps<{
+  menu?: Array<{ label: string; url: string }>
+  user?: { name?: string | null }
+  blocks: Array<{
+    type: string
+    props?: Record<string, any>
+  }>
+}>()
+</script>
+
+<template>
+  <LayoutBase :menu="menu" :user="user">
+    <BlockRenderer :blocks="blocks" />
+  </LayoutBase>
+</template>

--- a/nuxt-embed-example/components/layout/LayoutBase.vue
+++ b/nuxt-embed-example/components/layout/LayoutBase.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+const props = defineProps<{
+  menu?: Array<{ label: string; url: string }>
+  user?: { name?: string | null }
+}>()
+</script>
+
+<template>
+  <div class="page">
+    <header class="header">
+      <nav v-if="menu?.length" class="menu">
+        <a
+          v-for="item in menu"
+          :key="item.url"
+          :href="item.url"
+          class="menu-item"
+        >
+          {{ item.label }}
+        </a>
+      </nav>
+      <div v-if="user?.name" class="user">
+        Přihlášený: {{ user.name }}
+      </div>
+    </header>
+
+    <main class="content">
+      <slot />
+    </main>
+
+    <footer class="footer">
+      <small>© Example Nuxt Embed</small>
+    </footer>
+  </div>
+</template>

--- a/nuxt-embed-example/demo-server/package.json
+++ b/nuxt-embed-example/demo-server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nuxt-render-demo-server",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "dependencies": {
+    "express": "^4.19.0",
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/nuxt-embed-example/demo-server/server.mjs
+++ b/nuxt-embed-example/demo-server/server.mjs
@@ -1,0 +1,94 @@
+import express from 'express'
+import fetch from 'node-fetch'
+
+const app = express()
+app.use(express.json())
+
+const NUXT_URL = 'http://localhost:3000'
+
+app.get('/', async (_req, res) => {
+  try {
+    const payload = {
+      menu: [
+        { label: 'Domů', url: '/' },
+        { label: 'Produkty', url: '/products' }
+      ],
+      user: { name: 'David z Node demo' },
+      blocks: [
+        {
+          type: 'hero',
+          props: {
+            title: 'Stránka přes Node demo server',
+            subtitle: 'Payload jde z Node -> Nuxt -> HTML'
+          }
+        },
+        {
+          type: 'productList',
+          props: {
+            title: 'Top produkty z Node',
+            items: [
+              { name: 'Jablko', price: 10 },
+              { name: 'Chleba', price: 30 }
+            ]
+          }
+        }
+      ]
+    }
+
+    const nuxtResponse = await fetch(`${NUXT_URL}/render-page`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ payload })
+    })
+
+    if (!nuxtResponse.ok) {
+      const text = await nuxtResponse.text()
+      console.error('Nuxt error:', nuxtResponse.status, text)
+      return res.status(500).send('Nuxt render error')
+    }
+
+    const data = await nuxtResponse.json()
+    const htmlFragment = data.html
+
+    res.send(`<!doctype html>
+<html lang="cs">
+  <head>
+    <meta charset="utf-8">
+    <title>Node demo + Nuxt render-page</title>
+  </head>
+  <body>
+    ${htmlFragment}
+  </body>
+</html>`)
+  } catch (error) {
+    console.error(error)
+    res.status(500).send('Server error')
+  }
+})
+
+app.get('/hero-demo', async (_req, res) => {
+  const props = {
+    title: 'Single hero blok z Node',
+    subtitle: 'Render přes /render-block'
+  }
+
+  const propsString = encodeURIComponent(JSON.stringify(props))
+  const resp = await fetch(`${NUXT_URL}/render-block?component=hero&props=${propsString}`)
+  const html = await resp.text()
+
+  res.send(`<!doctype html>
+<html lang="cs">
+  <head>
+    <meta charset="utf-8">
+    <title>Single block demo</title>
+  </head>
+  <body>
+    ${html}
+  </body>
+</html>`)
+})
+
+const PORT = 4000
+app.listen(PORT, () => {
+  console.log(`Node demo server listening on http://localhost:${PORT}`)
+})

--- a/nuxt-embed-example/nuxt.config.ts
+++ b/nuxt-embed-example/nuxt.config.ts
@@ -1,0 +1,5 @@
+export default defineNuxtConfig({
+  compatibilityDate: '2024-04-03',
+  css: ['~/assets/styles.css'],
+  devtools: { enabled: true }
+})

--- a/nuxt-embed-example/package.json
+++ b/nuxt-embed-example/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "nuxt-embed-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "start": "nuxt start"
+  },
+  "dependencies": {
+    "nuxt": "^3.11.2"
+  }
+}

--- a/nuxt-embed-example/pages/index.vue
+++ b/nuxt-embed-example/pages/index.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import PageBridge from '~/components/bridge/PageBridge.vue'
+
+const { data: payload } = await useAsyncData('page-home', () =>
+  $fetch('/api/page-home')
+)
+</script>
+
+<template>
+  <PageBridge
+    v-if="payload"
+    :menu="payload.menu"
+    :user="payload.user"
+    :blocks="payload.blocks"
+  />
+  <div v-else>Loading...</div>
+</template>

--- a/nuxt-embed-example/server/api/page-home.get.ts
+++ b/nuxt-embed-example/server/api/page-home.get.ts
@@ -1,0 +1,30 @@
+export default defineEventHandler(async () => {
+  const payload = {
+    menu: [
+      { label: 'Domů', url: '/' },
+      { label: 'Produkty', url: '/products' }
+    ],
+    user: { name: 'David' },
+    blocks: [
+      {
+        type: 'hero',
+        props: {
+          title: 'Homepage z čistého Nuxt 3',
+          subtitle: 'Data jdou z /api/page-home'
+        }
+      },
+      {
+        type: 'productList',
+        props: {
+          title: 'Top produkty',
+          items: [
+            { name: 'Jablko', price: 10 },
+            { name: 'Chleba', price: 30 }
+          ]
+        }
+      }
+    ]
+  }
+
+  return payload
+})

--- a/nuxt-embed-example/server/routes/render-block.get.ts
+++ b/nuxt-embed-example/server/routes/render-block.get.ts
@@ -1,0 +1,40 @@
+import { h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const name = String(query.component || '')
+
+  if (!name) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing component name' })
+  }
+
+  const {
+    HeroBlock,
+    ProductListBlock
+  } = await import('#components')
+
+  const registry: Record<string, any> = {
+    hero: HeroBlock,
+    productList: ProductListBlock
+  }
+
+  if (!registry[name]) {
+    throw createError({ statusCode: 404, statusMessage: 'Unknown component' })
+  }
+
+  let props: Record<string, any> = {}
+  if (query.props) {
+    try {
+      props = JSON.parse(String(query.props))
+    } catch (error) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid props JSON' })
+    }
+  }
+
+  const Comp = registry[name]
+  const vnode = h(Comp as any, props)
+  const html = await renderToString(vnode)
+
+  return html
+})

--- a/nuxt-embed-example/server/routes/render-page.post.ts
+++ b/nuxt-embed-example/server/routes/render-page.post.ts
@@ -1,0 +1,28 @@
+import { h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+
+type Block = {
+  type: string
+  props?: Record<string, any>
+}
+
+type Payload = {
+  menu?: Array<{ label: string; url: string }>
+  user?: { name?: string | null }
+  blocks: Block[]
+}
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{ payload: Payload }>(event)
+
+  if (!body?.payload) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing payload' })
+  }
+
+  const { PageBridge } = await import('#components')
+
+  const vnode = h(PageBridge as any, body.payload)
+  const html = await renderToString(vnode)
+
+  return { html }
+})

--- a/nuxt-embed-example/tsconfig.json
+++ b/nuxt-embed-example/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}


### PR DESCRIPTION
## Summary
- add a Nuxt 3 embed example with shared layout, bridge component, and reusable block renderer
- expose render-page and render-block server routes plus a sample home API/page powered by the payload
- include a demo Node server and documentation showing how to call the Nuxt renderer from an external app

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921dad02ed883239fdbd5a73b7fc30d)